### PR TITLE
Don't kill front-end when back-end proxying fails

### DIFF
--- a/build/main.gulp.js
+++ b/build/main.gulp.js
@@ -329,7 +329,14 @@
           var url = target + req.url;
           var method = (req.method + '        ').substring(0, 8);
           gutil.log(method, req.url);
-          req.pipe(proxiedRequest(url)).pipe(res);
+          var p = proxiedRequest(url);
+          p.on('error', function (e) {
+            gutil.log(e);
+            res.writeHead(500, { 'Content-Type': 'text/plain' });
+            res.write(e.toString());
+            res.end();
+          });
+          req.pipe(p).pipe(res);
         }
       };
       middleware.push(proxyMiddleware);

--- a/build/server.js
+++ b/build/server.js
@@ -39,7 +39,12 @@
     secure: false
   });
 
-  app.use(function (req, res, next) {
+  // Handle errors - otherwise teh proxy library will just abort
+  proxy.on('error', function (err) {
+    console.log('\x1b[31mError proxying request: %s\x1b[0m', err.code);
+  });
+
+  app.use(function (req, res) {
     // Only proxy requests that start /pp
     if (req.url.indexOf('/pp/') !== 0) {
       console.log('\x1b[31m%s %s\x1b[0m', req.method, req.url);
@@ -48,12 +53,7 @@
       if (!doNotLogRequests) {
         console.log('\x1b[36m%s %s\x1b[0m', req.method, req.url);
       }
-      try {
-        return proxy.web(req, res);
-      } catch (e) {
-        console.log('\x1b[31mError proxying request: %s\x1b[0m', req.url);
-      }
-      return next();
+      return proxy.web(req, res);
     }
   });
 


### PR DESCRIPTION
Updated both 'dev' and 'run' targets so that if the proxying of the back-end request fails, the front-end will not terminate.