### PR TITLE
Convert app wall and endpoint header button groups to action toolbars

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Stratos UI can be deployed in the following environments:
 3. Docker, using docker compose. See [guide](deploy/docker-compose)
 4. Docker, single container deploying all components. See [guide](deploy/all-in-one)
 
+
 ## Quick Start
 
 To get started quickly, we recommend following the steps to deploy the Stratos UI Console as a Cloud Foundry Application - see [here](deploy/cloud-foundry).

--- a/components/about-app/src/about-app.html
+++ b/components/about-app/src/about-app.html
@@ -1,4 +1,4 @@
-<div class="action-bar app-actions-bar col-md-12 panel-less">
+<div class="action-bar col-md-12 panel-less">
   <div ng-if="!applicationsListCtrl.needAdminSetup" class="applications-header font-semi-bold pull-left" translate>about</div>
 </div>
 

--- a/components/app-core/frontend/src/view/console-view/console-view.scss
+++ b/components/app-core/frontend/src/view/console-view/console-view.scss
@@ -53,9 +53,5 @@ console-view {
   console-view, console-view.navbar-icons-only {
     width: 100vw;
     margin-left: 0;
-
-    .app-top-bar {
-      margin-left: 0;
-    }
   }
 }

--- a/components/app-core/frontend/src/view/endpoints/endpoints.scss
+++ b/components/app-core/frontend/src/view/endpoints/endpoints.scss
@@ -7,16 +7,6 @@
   justify-content: center;
   align-items: stretch;
 
-  .header {
-    padding-top: $console-unit-space;
-    padding-bottom: $console-unit-space;
-    position: relative;
-    button {
-      position: absolute;
-      right: 0;
-    }
-  }
-
   .welcome-message {
 
     > .material-icons {

--- a/components/app-core/frontend/src/view/view.scss
+++ b/components/app-core/frontend/src/view/view.scss
@@ -51,21 +51,6 @@ paginator {
   padding: $console-unit-space / 4 $console-unit-space * 2 / 3;
 }
 
-.applications-header {
-  font-size: $font-size-heading;
-
-  .applications-count {
-    word-spacing: -2px;
-    font-size: $console-unit-space - $console-unit-space / 4;
-    padding-left: $console-unit-space / 4;
-    display: inline;
-  }
-
-  .bounce-spinner-sm {
-    margin-left: $console-unit-space;
-  }
-}
-
 .action-bar {
   line-height: $console-unit-space * 3;
   vertical-align: middle;

--- a/components/app-framework/src/widgets/actions-menu/actions-menu.directive.js
+++ b/components/app-framework/src/widgets/actions-menu/actions-menu.directive.js
@@ -116,7 +116,7 @@
     $scope.$watch(function () {
       if (vm.actions && vm.actions.length > 0) {
         return _.countBy(vm.actions, function (action) {
-          return !!action.hidden;
+          return executeOrReturn(action, 'hidden');
         }).false;
       }
       return 0;
@@ -140,7 +140,7 @@
      * @returns {void}
      */
     function executeAction($event, action) {
-      if (!action.disabled) {
+      if (!executeOrReturn(action, 'disabled')) {
         action.execute(vm.actionTarget);
         this.open = false;
       }

--- a/components/app-framework/src/widgets/actions-menu/actions-menu.directive.js
+++ b/components/app-framework/src/widgets/actions-menu/actions-menu.directive.js
@@ -116,7 +116,7 @@
     $scope.$watch(function () {
       if (vm.actions && vm.actions.length > 0) {
         return _.countBy(vm.actions, function (action) {
-          return executeOrReturn(action, 'hidden');
+          return !!executeOrReturn(action, 'hidden');
         }).false;
       }
       return 0;

--- a/components/app-framework/src/widgets/actions-menu/actions-menu.directive.js
+++ b/components/app-framework/src/widgets/actions-menu/actions-menu.directive.js
@@ -111,6 +111,7 @@
     vm.menuIconName = vm.menuIconName || 'more_horiz';
 
     vm.executeAction = executeAction;
+    vm.executeOrReturn = executeOrReturn;
 
     $scope.$watch(function () {
       if (vm.actions && vm.actions.length > 0) {
@@ -145,6 +146,14 @@
       }
       $event.stopPropagation();
     }
+
+    function executeOrReturn(action, property) {
+      if (angular.isFunction(action[property])) {
+        return action[property]();
+      }
+      return action[property];
+    }
+
   }
 
 })();

--- a/components/app-framework/src/widgets/actions-menu/actions-menu.html
+++ b/components/app-framework/src/widgets/actions-menu/actions-menu.html
@@ -14,8 +14,10 @@
         <span translate>{{ actionsMenuCtrl.menuLabel }}</span>
       </li>
       <li class="actions-menu-item" ng-repeat="action in actionsMenuCtrl.actions"
-          ng-click="actionsMenuCtrl.executeAction($event, action)" tabindex="0"
-          ng-disabled="action.disabled" ng-hide="action.hidden">
+          ng-click="actionsMenuCtrl.executeAction($event, action)"
+          tabindex="0"
+          ng-disabled="actionsMenuCtrl.executeOrReturn(action, 'disabled')"
+          ng-hide="actionsMenuCtrl.executeOrReturn(action, 'hidden')">
         <i ng-class="action.icon" ng-if="action.icon"></i>
         <span translate>{{ action.name }}</span>
       </li>

--- a/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.directive.js
+++ b/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.directive.js
@@ -92,6 +92,15 @@
           onResize();
         }
       });
+
+      scope.executeOrReturn = executeOrReturn;
+
+      function executeOrReturn(action, property) {
+        if (angular.isFunction(action[property])) {
+          return action[property]();
+        }
+        return action[property];
+      }
     }
   }
 

--- a/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.directive.js
+++ b/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.directive.js
@@ -84,7 +84,7 @@
         var s = '';
         _.each(ctrl.items, function (item) {
           s += '(' + item.id || item.name;
-          s += '-' + item.hidden + '-' + item.disabled + ')';
+          s += '-' + executeOrReturn(item, 'hidden') + '-' + executeOrReturn(item, 'disabled') + ')';
         });
         return s;
       }, function (newValue, oldValue) {

--- a/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.html
+++ b/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.html
@@ -2,8 +2,8 @@
   <button
     ng-repeat="action in actionsToolbarCtrl.items"
     class="no-focus btn btn-link btn-border-less actions-toolbar-btn"
-    ng-disabled="action.disabled"
-    ng-hide="action.hidden"
+    ng-disabled="actionsToolbarCtrl.executeOrReturn(action, 'disabled')"
+    ng-hide="actionsToolbarCtrl.executeOrReturn(action, 'hidden')"
     ng-click="action.execute()">
     <app-icon icon-class="{{action.iconClass}}" class="actions-toolbar-icon" icon="{{action.icon}}"></app-icon>
     <span>{{ action.name | translate }}</span>

--- a/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.html
+++ b/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.html
@@ -2,6 +2,7 @@
 
   <button
     ng-repeat="action in actionsToolbarCtrl.items"
+    id="{{action.id}}"
     class="no-focus btn btn-link btn-border-less actions-toolbar-btn"
     ng-disabled="executeOrReturn(action, 'disabled')"
     ng-hide="executeOrReturn(action, 'hidden')"

--- a/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.html
+++ b/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.html
@@ -1,15 +1,15 @@
 <div class="actions-toolbar">
+
   <button
     ng-repeat="action in actionsToolbarCtrl.items"
     class="no-focus btn btn-link btn-border-less actions-toolbar-btn"
-    ng-disabled="actionsToolbarCtrl.executeOrReturn(action, 'disabled')"
-    ng-hide="actionsToolbarCtrl.executeOrReturn(action, 'hidden')"
+    ng-disabled="executeOrReturn(action, 'disabled')"
+    ng-hide="executeOrReturn(action, 'hidden')"
     ng-click="action.execute()">
     <app-icon icon-class="{{action.iconClass}}" class="actions-toolbar-icon" icon="{{action.icon}}"></app-icon>
     <span>{{ action.name | translate }}</span>
   </button>
 </div>
-
 <actions-menu actions="actionsToolbarCtrl.items"
   menu-before-open="actionsToolbarCtrl.onOpenMenu"
   menu-icon-name="more_vert"

--- a/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.scss
+++ b/components/app-framework/src/widgets/actions-toolbar/actions-toolbar.scss
@@ -53,7 +53,7 @@ actions-toolbar {
       > app-icon {
         display: inline-block;
         vertical-align: middle;
-        line-height: normal;
+        line-height: 1;
 
         > svg {
           width: $actions-toolbar-icon-svg-size;

--- a/components/cf-app-push/frontend/src/view/deploy-app-workflow/deploy-app.service.js
+++ b/components/cf-app-push/frontend/src/view/deploy-app-workflow/deploy-app.service.js
@@ -43,7 +43,6 @@
         icon: 'add_to_queue',
         position: 2,
         hidden: function () {
-          // return false;
           var hidden = _.get(this.context, 'hidden');
           if (angular.isFunction(hidden)) {
             return hidden();

--- a/components/cf-app-push/frontend/src/view/deploy-app-workflow/deploy-app.service.js
+++ b/components/cf-app-push/frontend/src/view/deploy-app-workflow/deploy-app.service.js
@@ -39,26 +39,31 @@
     function register() {
       cfAppWallActions.actions.push({
         id: 'app-wall-deploy-application-btn',
-        label: 'app-wall.deploy-application',
+        name: 'app-wall.deploy-application',
+        icon: 'add_to_queue',
         position: 2,
-        show: function (context) {
-          if (angular.isFunction(context.show)) {
-            return context.show();
-          }
-          return true;
-        },
-        disable: function (context) {
-          if (angular.isFunction(context.disable)) {
-            return context.disable();
+        hidden: function () {
+          // return false;
+          var hidden = _.get(this.context, 'hidden');
+          if (angular.isFunction(hidden)) {
+            return hidden();
           }
           return false;
         },
-        action: function (context) {
+        disabled: function () {
+          var disabled = _.get(this.context, 'disabled');
+          if (angular.isFunction(disabled)) {
+            return disabled();
+          }
+          return false;
+        },
+        execute: function () {
+          var reload = _.get(this.context, 'reload');
           deploy().result.catch(function (result) {
             // Do we need to reload the app collection to show the newly added app?
-            if (_.get(result, 'reload') && angular.isFunction(context.reload)) {
+            if (_.get(result, 'reload') && angular.isFunction(reload)) {
               // Note - this won't show the app if the user selected a different cluster/org/guid than that of the filter
-              context.reload();
+              reload();
             }
           });
         }

--- a/components/cloud-foundry/frontend/src/services/app-wall-actions.service.js
+++ b/components/cloud-foundry/frontend/src/services/app-wall-actions.service.js
@@ -21,21 +21,24 @@
 
     service.actions.push({
       id: 'app-wall-add-new-application-btn',
-      label: 'app-wall.add-application',
+      name: 'app-wall.add-application',
+      icon: 'add_to_queue',
       position: 1,
-      show: function (context) {
-        if (angular.isFunction(context.show)) {
-          return context.show();
-        }
-        return true;
-      },
-      disable: function (context) {
-        if (angular.isFunction(context.disable)) {
-          return context.disable();
+      hidden: function () {
+        var hidden = _.get(this.context, 'hidden');
+        if (angular.isFunction(hidden)) {
+          return hidden();
         }
         return false;
       },
-      action: function addApplication() {
+      disabled: function () {
+        var disabled = _.get(this.context, 'disabled');
+        if (angular.isFunction(disabled)) {
+          return disabled();
+        }
+        return false;
+      },
+      execute: function addApplication() {
         frameworkDetailView(
           {
             templateUrl: 'plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-dialog.html',

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.html
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.html
@@ -1,20 +1,7 @@
-<div class="app-top-bar action-bar app-actions-bar panel-less application-wall-header">
-  <div class="applications-header font-semi-bold">
-    <span translate>app-wall</span>
-    <bounce-spinner classes="bounce-spinner-sm" ng-if="applicationsListCtrl.loading"></bounce-spinner>
-  </div>
-  <div class="application-header-right">
-    <actions-toolbar ready="applicationsListCtrl.ready" items="applicationsListCtrl.appWallActions"></actions-toolbar>
-
-
-    <!--<button ng-repeat="action in applicationsListCtrl.appWallActions | orderBy:'position'"-->
-            <!--id="{{action.id}}"-->
-            <!--class="btn btn-primary"-->
-            <!--ng-if="action.show(applicationsListCtrl.appWallActionContext)"-->
-            <!--ng-disabled="action.disable(applicationsListCtrl.appWallActionContext)"-->
-            <!--ng-click="action.action(applicationsListCtrl.appWallActionContext)">{{action.label | translate}}-->
-    <!--</button>-->
-  </div>
+<div class="applications-header font-semi-bold">
+  <span translate>app-wall</span>
+  <bounce-spinner classes="bounce-spinner-sm" ng-if="applicationsListCtrl.loading"></bounce-spinner>
+  <actions-toolbar ready="applicationsListCtrl.ready" items="applicationsListCtrl.appWallActions"></actions-toolbar>
 </div>
 
 <div ng-if="applicationsListCtrl.ready">

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.html
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.html
@@ -1,4 +1,4 @@
-<div class="applications-header font-semi-bold">
+<div class="applications-header apps-header font-semi-bold">
   <span translate>app-wall</span>
   <bounce-spinner classes="bounce-spinner-sm" ng-if="applicationsListCtrl.loading"></bounce-spinner>
   <actions-toolbar ready="applicationsListCtrl.ready" items="applicationsListCtrl.appWallActions"></actions-toolbar>

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.html
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.html
@@ -4,13 +4,16 @@
     <bounce-spinner classes="bounce-spinner-sm" ng-if="applicationsListCtrl.loading"></bounce-spinner>
   </div>
   <div class="application-header-right">
-    <button ng-repeat="action in applicationsListCtrl.appWallActions | orderBy:'position'"
-            id="{{action.id}}"
-            class="btn btn-primary"
-            ng-if="action.show(applicationsListCtrl.appWallActionContext)"
-            ng-disabled="action.disable(applicationsListCtrl.appWallActionContext)"
-            ng-click="action.action(applicationsListCtrl.appWallActionContext)">{{action.label | translate}}
-    </button>
+    <actions-toolbar ready="applicationsListCtrl.ready" items="applicationsListCtrl.appWallActions"></actions-toolbar>
+
+
+    <!--<button ng-repeat="action in applicationsListCtrl.appWallActions | orderBy:'position'"-->
+            <!--id="{{action.id}}"-->
+            <!--class="btn btn-primary"-->
+            <!--ng-if="action.show(applicationsListCtrl.appWallActionContext)"-->
+            <!--ng-disabled="action.disable(applicationsListCtrl.appWallActionContext)"-->
+            <!--ng-click="action.action(applicationsListCtrl.appWallActionContext)">{{action.label | translate}}-->
+    <!--</button>-->
   </div>
 </div>
 

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
@@ -91,22 +91,13 @@
       disabled: disableChangeAppListAction,
       reload: _reload
     };
-    var appWallActions = [
-      {
-        name: 'app.app-info.app-actions.view',
-        execute: function () {
-        },
-        disabled: true,
-        id: 'launch',
-        icon: 'launch'
-      }
-    ];
-    //TODO: RC chain
-    appWallActions = _.map(cfAppWallActions.actions, function (action) {
-      action.context = appWallActionContext;
-      return action;
-    });
-    vm.appWallActions = _.orderBy(appWallActions, 'position', 'asc');
+    vm.appWallActions = _.chain(cfAppWallActions.actions)
+      .map(function (action) {
+        action.context = appWallActionContext;
+        return action;
+      })
+      .orderBy('position', 'asc')
+      .value();
 
     vm.addApplication = addApplication;
     angular.element($window).on('resize', onResize);

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
@@ -86,12 +86,28 @@
     vm.resetFilter = resetFilter;
     vm.isAdminInAnyCf = isAdminInAnyCf;
     vm.goToGalleryView = goToGalleryView;
-    vm.appWallActions = cfAppWallActions.actions;
-    vm.appWallActionContext = {
-      show: showChangeAppListAction,
-      disable: disableChangeAppListAction,
+    var appWallActionContext = {
+      hidden: hideChangeAppListAction,
+      disabled: disableChangeAppListAction,
       reload: _reload
     };
+    var appWallActions = [
+      {
+        name: 'app.app-info.app-actions.view',
+        execute: function () {
+        },
+        disabled: true,
+        id: 'launch',
+        icon: 'launch'
+      }
+    ];
+    //TODO: RC chain
+    appWallActions = _.map(cfAppWallActions.actions, function (action) {
+      action.context = appWallActionContext;
+      return action;
+    });
+    vm.appWallActions = _.orderBy(appWallActions, 'position', 'asc');
+
     vm.addApplication = addApplication;
     angular.element($window).on('resize', onResize);
 
@@ -508,14 +524,14 @@
       }
     }
 
-    function showChangeAppListAction() {
-      return isAdminInAnyCf() || vm.isSpaceDeveloper;
+    function hideChangeAppListAction() {
+      return !isAdminInAnyCf() && !vm.isSpaceDeveloper;
     }
 
     function addApplication() {
       var addAppAction = _.find(cfAppWallActions.actions, 'id', 'app-wall-add-new-application-btn');
       if (addAppAction) {
-        addAppAction.action();
+        addAppAction.execute();
       }
     }
 

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.scss
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.scss
@@ -9,7 +9,7 @@ $applications-msg-height: 50px;
   height: $main-nav-title-height;
 
   &.apps-header {
-    padding: 0 15px;
+    padding: 0 $panel-body-padding;
   }
 
   bounce-spinner {

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.scss
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.scss
@@ -6,9 +6,11 @@ $applications-msg-height: 50px;
 .applications-header {
   @include flex-vertical-centered();
   font-size: $console-unit-space;
-  padding: 0 15px;
   height: $main-nav-title-height;
 
+  &.apps-header {
+    padding: 0 15px;
+  }
 
   bounce-spinner {
     margin-left: $console-unit-space / 2;

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.scss
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.scss
@@ -5,66 +5,71 @@ $applications-msg-height: 50px;
 
 .application-wall-header.action-bar {
   display: flex;
-  flex-wrap: wrap;
+  //flex-wrap: wrap;
   line-height: $main-nav-item-height;
 
   .application-header-right {
-    flex-grow: 1;
+    //flex-grow: 1;
+    flex: 1;
     justify-content: flex-end;
     align-items: center;
     display: flex;
     min-height: $main-nav-item-height;
 
-    .btn-primary {
-      font-size: $font-size-base;
-      font-weight: $console-font-weight-strongbold;
-      height: auto;
-      padding: 4px $console-unit-space;
+    actions-toolbar .actions-toolbar {
+      min-height: $main-nav-item-height;
     }
+
+    //.btn-primary {
+    //  font-size: $font-size-base;
+    //  font-weight: $console-font-weight-strongbold;
+    //  height: auto;
+    //  padding: 4px $console-unit-space;
+    //}
   }
 }
 
-.application-header-centre {
-  flex-grow: 1;
-
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  flex-wrap: wrap;
-  margin-left: $console-unit-space;
-
-  .form-group.search-field {
-    height: 40px;
-    display: flex;
-    margin-top: -1px;
-    align-items: center;
-    input {
-      margin-bottom: 0;
-    }
-  }
-}
+//.application-header-centre {
+//  flex-grow: 1;
+//
+//  display: flex;
+//  justify-content: flex-end;
+//  align-items: center;
+//  flex-wrap: wrap;
+//  margin-left: $console-unit-space;
+//
+//  .form-group.search-field {
+//    height: 40px;
+//    display: flex;
+//    margin-top: -1px;
+//    align-items: center;
+//    input {
+//      margin-bottom: 0;
+//    }
+//  }
+//}
 
 @media (max-width: 745px) {
   .application-header-centre {
-    margin-left: 0;
-    justify-content: flex-start;
+    //margin-left: 0;
+    //justify-content: flex-start;
   }
   .application-header-right {
-    & > button.btn {
-      margin-left: 0;
-    }
+    //& > button.btn {
+    //  margin-left: 0;
+    //}
   }
 }
 
 @media (max-width: 549px) {
-  .application-header-centre {
-    .view-buttons {
-      margin-left: 0;
-      button {
-        border: none;
-      }
-    }
-  }
+  //.application-header-centre {
+  //  .view-buttons {
+  //    margin-left: 0;
+  //    button {
+  //      border: none;
+  //    }
+  //  }
+  //}
 }
 
 .applications-filter {

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.scss
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.scss
@@ -3,73 +3,23 @@
 
 $applications-msg-height: 50px;
 
-.application-wall-header.action-bar {
-  display: flex;
-  //flex-wrap: wrap;
-  line-height: $main-nav-item-height;
+.applications-header {
+  @include flex-vertical-centered();
+  font-size: $console-unit-space;
+  padding: 0 15px;
+  height: $main-nav-title-height;
 
-  .application-header-right {
-    //flex-grow: 1;
-    flex: 1;
-    justify-content: flex-end;
-    align-items: center;
-    display: flex;
-    min-height: $main-nav-item-height;
 
-    actions-toolbar .actions-toolbar {
-      min-height: $main-nav-item-height;
+  bounce-spinner {
+    margin-left: $console-unit-space / 2;
+    vertical-align: middle;
+    line-height: 1;
+    .bounce-spinner {
+      display: block;
+      width: 46px;
     }
-
-    //.btn-primary {
-    //  font-size: $font-size-base;
-    //  font-weight: $console-font-weight-strongbold;
-    //  height: auto;
-    //  padding: 4px $console-unit-space;
-    //}
   }
-}
 
-//.application-header-centre {
-//  flex-grow: 1;
-//
-//  display: flex;
-//  justify-content: flex-end;
-//  align-items: center;
-//  flex-wrap: wrap;
-//  margin-left: $console-unit-space;
-//
-//  .form-group.search-field {
-//    height: 40px;
-//    display: flex;
-//    margin-top: -1px;
-//    align-items: center;
-//    input {
-//      margin-bottom: 0;
-//    }
-//  }
-//}
-
-@media (max-width: 745px) {
-  .application-header-centre {
-    //margin-left: 0;
-    //justify-content: flex-start;
-  }
-  .application-header-right {
-    //& > button.btn {
-    //  margin-left: 0;
-    //}
-  }
-}
-
-@media (max-width: 549px) {
-  //.application-header-centre {
-  //  .view-buttons {
-  //    margin-left: 0;
-  //    button {
-  //      border: none;
-  //    }
-  //  }
-  //}
 }
 
 .applications-filter {

--- a/components/cloud-foundry/frontend/src/view/dashboard/tiles/cluster-tiles.html
+++ b/components/cloud-foundry/frontend/src/view/dashboard/tiles/cluster-tiles.html
@@ -18,9 +18,7 @@
       </div>
     </div>
     <div ng-switch-default>
-      <div class="header">
-        <div class="applications-header font-semi-bold pull-left" translate>cloud-foundry</div>
-      </div>
+      <div class="applications-header font-semi-bold pull-left" translate>cloud-foundry</div>
       <div class="cluster-gallery-card-container">
         <div class="cluster-gallery-card-parent clusters-card col-md-4 col-sm-1" ng-repeat="(guid, service) in clustersCtrl.serviceInstances">
           <cluster-tile service="service"/>

--- a/components/cloud-foundry/frontend/test/e2e/application-wall.spec.js
+++ b/components/cloud-foundry/frontend/test/e2e/application-wall.spec.js
@@ -26,7 +26,7 @@
       });
 
       it('The page should have title "Applications"', function () {
-        expect(element(by.css('.applications-header')).getText()).toBe('Applications');
+        expect(applicationWall.getTitle()).toBe('Applications');
       });
 
       it('should show application message: "You cannot view any applications."', function () {
@@ -36,7 +36,7 @@
       });
 
       it('should not see ADD APPLICATION botton', function () {
-        expect(element(by.css('.btn.btn-primary')).isPresent()).not.toBeTruthy();
+        expect(applicationWall.getAddApplicationButton().isDisplayed()).not.toBeTruthy();
       });
     });
 
@@ -53,7 +53,7 @@
       });
 
       it('The page should have title "Applications"', function () {
-        expect(element(by.css('.applications-header')).getText()).toBe('Applications');
+        expect(applicationWall.getTitle()).toBe('Applications');
       });
 
       /*
@@ -79,9 +79,8 @@
       });
 
       it('should see an ADD APPLICATION button.', function () {
-        var btn = element(by.css('.btn.btn-primary'));
-        expect(btn.isPresent()).toBeTruthy();
-        expect(btn.getText()).toBe('ADD APPLICATION');
+        var btn = applicationWall.getAddApplicationButton();
+        expect(btn.isDisplayed()).toBeTruthy();
       });
 
       it('should not see no-application message.', function () {
@@ -140,7 +139,7 @@
       });
 
       it('The page should have title "Applications"', function () {
-        expect(element(by.css('.applications-header')).getText()).toBe('Applications');
+        expect(applicationWall.getTitle()).toBe('Applications');
         expect(applicationWall.getAppCount()).toBe('500');
       });
 

--- a/components/cloud-foundry/frontend/test/e2e/po/applications/applications.po.js
+++ b/components/cloud-foundry/frontend/test/e2e/po/applications/applications.po.js
@@ -6,6 +6,7 @@
   var inputSelectInput = require('../../../../../../app-core/frontend/test/e2e/po/widgets/input-select-input.po');
 
   module.exports = {
+    getTitle: getTitle,
 
     applicationGalleryCards: applicationGalleryCards,
     applicationGalleryCard: applicationGalleryCard,
@@ -36,6 +37,10 @@
     isListView: isListView
 
   };
+
+  function getTitle() {
+    return element(by.css('.applications-header > span')).getText();
+  }
 
   function applicationGalleryCard(idx) {
     return applicationGalleryCards().get(idx)

--- a/components/cloud-foundry/frontend/test/e2e/po/endpoints/endpoints-list-cf.po.js
+++ b/components/cloud-foundry/frontend/test/e2e/po/endpoints/endpoints-list-cf.po.js
@@ -77,7 +77,7 @@
   }
 
   function headerRegisterVisible() {
-    return getHeaderRegister().isPresent();
+    return getHeaderRegister().isDisplayed();
   }
 
   function getHeaderRegister() {

--- a/components/cloud-foundry/frontend/test/unit/view/applications/list/list.module.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/applications/list/list.module.spec.js
@@ -3,7 +3,7 @@
 
   describe('list module', function () {
 
-    var $controller, $httpBackend, $scope, $state;
+    var $controller, $httpBackend, $scope, $state, appWallActionContext;
 
     var cnsiGuid = 'cnsiGuid';
     // Matches org from ListAllOrganizations
@@ -72,6 +72,7 @@
         $httpBackend.whenGET(GetDetailedStatsForStartedApp.url).respond(200, GetDetailedStatsForStartedApp.response[200].body);
       });
 
+      appWallActionContext = $controller.appWallActions[0].context;
     }
 
     afterEach(function () {
@@ -490,7 +491,7 @@
       });
 
       it('should show `Add Application` button to user', function () {
-        expect($controller.appWallActionContext.show()).toBe(true);
+        expect(appWallActionContext.hidden()).toBe(false);
       });
     });
 
@@ -503,7 +504,7 @@
       it('should show `Add Application` button to user', function () {
         $controller.ready = true;
         $httpBackend.flush();
-        expect($controller.appWallActionContext.show()).toBe(true);
+        expect(appWallActionContext.hidden()).toBe(false);
       });
     });
 
@@ -516,7 +517,7 @@
       it('should hide `Add Application` button to user', function () {
         $controller.ready = true;
         $httpBackend.flush();
-        expect($controller.appWallActionContext.show()).toBe(false);
+        expect(appWallActionContext.hidden()).toBe(true);
       });
     });
 

--- a/components/endpoints-dashboard/i18n/en/dashboard.json
+++ b/components/endpoints-dashboard/i18n/en/dashboard.json
@@ -1,7 +1,7 @@
 {
   "endpoints-dashboard": {
     "title": "Endpoints",
-    "register-button": "register endpoint",
+    "register-button": "Register Endpoint",
     "table": {
       "name": "name",
       "connection": "connection",

--- a/components/endpoints-dashboard/src/view/view.html
+++ b/components/endpoints-dashboard/src/view/view.html
@@ -1,14 +1,8 @@
 <div class="endpoints endpoints-dashboard">
-  <div class="header">
-    <div class="applications-header font-semi-bold pull-left" translate>
-      endpoints-dashboard.title
-      <bounce-spinner classes="bounce-spinner-sm" ng-if="!endpointsDashboardCtrl.initialised"></bounce-spinner>
-    </div>
-    <button ng-if="endpointsDashboardCtrl.initialised &&
-                     endpointsDashboardCtrl.isUserAdmin()"
-            class="btn btn-primary" stlye="position: absolute; right: 0px;"
-            ng-click="endpointsDashboardCtrl.register()" translate>endpoints-dashboard.register-button
-    </button>
+  <div class="applications-header font-semi-bold pull-left">
+    <span translate>endpoints-dashboard.title</span>
+    <bounce-spinner classes="bounce-spinner-sm" ng-if="!endpointsDashboardCtrl.initialised"></bounce-spinner>
+    <actions-toolbar ready="endpointsDashboardCtrl.initialised" items="endpointsDashboardCtrl.headerActions"></actions-toolbar>
   </div>
   <div class="console-error console-error-block" ng-if="endpointsDashboardCtrl.initialised && endpointsDashboardCtrl.listError">
     <div>

--- a/components/endpoints-dashboard/src/view/view.module.js
+++ b/components/endpoints-dashboard/src/view/view.module.js
@@ -38,11 +38,13 @@
 
     vm.endpoints = undefined;
     vm.initialised = false;
+    vm.register = register;
     vm.hideWelcomeMessage = hideWelcomeMessage;
     vm.isUserAdmin = isUserAdmin;
     vm.reload = reload;
     vm.headerActions = [
       {
+        id: 'endpoints-dashboard.register-button',
         name: 'endpoints-dashboard.register-button',
         execute: register,
         hidden: function () {

--- a/components/endpoints-dashboard/src/view/view.module.js
+++ b/components/endpoints-dashboard/src/view/view.module.js
@@ -38,10 +38,20 @@
 
     vm.endpoints = undefined;
     vm.initialised = false;
-    vm.register = register;
     vm.hideWelcomeMessage = hideWelcomeMessage;
     vm.isUserAdmin = isUserAdmin;
     vm.reload = reload;
+    vm.headerActions = [
+      {
+        name: 'endpoints-dashboard.register-button',
+        execute: register,
+        hidden: function () {
+          return !isUserAdmin();
+        },
+        disabled: vm.initialised,
+        icon: 'add_box'
+      }
+    ];
 
     appEndpointsDashboardService.refreshFromCache();
     if (appEndpointsDashboardService.endpoints.length !== 0) {

--- a/components/endpoints-dashboard/test/e2e/po/endpoints/endpoints-dashboard.po.js
+++ b/components/endpoints-dashboard/test/e2e/po/endpoints/endpoints-dashboard.po.js
@@ -222,7 +222,7 @@
   }
 
   function getHeaderRegister() {
-    return element(by.css('.endpoints-dashboard .header button'));
+    return element(by.id('endpoints-dashboard.register-button'));
   }
 
   function headerRegister() {
@@ -230,7 +230,7 @@
   }
 
   function headerRegisterVisible() {
-    return getHeaderRegister().isPresent();
+    return getHeaderRegister().isDisplayed();
   }
 
   function credentialsForm() {

--- a/components/endpoints-dashboard/test/unit/view/endpoints-dashboard.module.spec.js
+++ b/components/endpoints-dashboard/test/unit/view/endpoints-dashboard.module.spec.js
@@ -110,7 +110,7 @@
       });
 
       it('should show cluster registration detail view when showClusterAddForm is invoked', function () {
-        controller.register();
+        controller.headerActions[0].execute();
         $scope.$digest();
         expect(registerServiceCalled).toBe(true);
         $httpBackend.flush();


### PR DESCRIPTION
- Most of the work revolves around making the action-menu and action-toolbars 'hidden' and 'disabled' work as bools or functions
- Includes removal of some old classes
- Harmonised the app wall header with the app page header