### PR TITLE
Add extension points for cluster/org/space tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Stratos UI can be deployed in the following environments:
 3. Docker, using docker compose. See [guide](deploy/docker-compose)
 4. Docker, single container deploying all components. See [guide](deploy/all-in-one)
 
+
 ## Quick Start
 
 To get started quickly, we recommend following the steps to deploy the Stratos UI Console as a Cloud Foundry Application - see [here](deploy/cloud-foundry).

--- a/components/cf-app-ssh/frontend/src/view/ssh.module.js
+++ b/components/cf-app-ssh/frontend/src/view/ssh.module.js
@@ -24,6 +24,9 @@
         return !cfUtilsService.hasSshAccess(cnsiModel.serviceInstances[cnsiGuid]);
       },
       uiSref: 'cf.applications.application.ssh',
+      uiSrefParam: function () {
+        return {guid: $stateParams.guid};
+      },
       label: 'cf.app-ssh',
       clearState: function () {
       }

--- a/components/cloud-foundry/frontend/src/services/tabs.service.js
+++ b/components/cloud-foundry/frontend/src/services/tabs.service.js
@@ -2,18 +2,18 @@
   'use strict';
 
   angular
-    .module('cloud-foundry.view.dashboard.cluster')
-    .factory('cfClusterTabs', ClusterTabs);
+    .module('cloud-foundry.service')
+    .factory('cfTabs', CfClusterTabs);
 
   /**
-   * @name cfClusterTabs
+   * @name cfTabs
    * @description Provides collection of configuration objects for tabs on the cluster, org and space pages
    * @param {object} $q - the Angular $q service
    * @param {object} $stateParams - the Angular $stateParams service
    * @param {app.model.modelManager} modelManager - the application model manager
-   * @returns {object} The cfClusterTabs service
+   * @returns {object} The cfTabs service
    */
-  function ClusterTabs($q, $stateParams, modelManager) {
+  function CfClusterTabs($q, $stateParams, modelManager) {
 
     return {
       applicationTabs: [],

--- a/components/cloud-foundry/frontend/src/view/applications/application/app-events/app-events.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/application/app-events/app-events.module.js
@@ -22,6 +22,9 @@
         return false;
       },
       uiSref: 'cf.applications.application.events',
+      uiSrefParam: function () {
+        return {guid: $stateParams.guid};
+      },
       label: 'app.app-info.app-tabs.events',
       clearState: function () {}
     });

--- a/components/cloud-foundry/frontend/src/view/applications/application/application-tabs.service.js
+++ b/components/cloud-foundry/frontend/src/view/applications/application/application-tabs.service.js
@@ -9,12 +9,12 @@
    * @name cfApplicationTabs
    * @description Provides collection of configuration objects for tabs on the application page
    * @param {object} $q - the Angular $q service
+   * @param {object} cfClusterTabs - the core cf tabs service
    * @returns {object} The cfApplicationTabs object
    */
-  function ApplicationTabs($q) {
+  function ApplicationTabs(cfClusterTabs) {
     var service = {
-      tabs: [ ],
-      callAppTabs: callAppTabs,
+      tabs: cfClusterTabs.applicationTabs,
       clearState: clearState,
       appUpdated: appUpdated,
       appDeleting: appDeleting,
@@ -23,34 +23,20 @@
 
     return service;
 
-    function callAppTabs(method) {
-      var tasks = [];
-      var args = Array.prototype.slice.call(arguments, 1);
-      _.forEach(service.tabs, function (tab) {
-        var promise = _safeCallFunction.apply(tab, [tab, tab[method]].concat(args));
-        tasks.push(promise || $q.resolve());
-      });
-      return $q.all(tasks);
-    }
-
     function clearState() {
-      return callAppTabs.apply(service, ['clearState']);
+      return cfClusterTabs.callTabs([service.tabs], 'clearState');
     }
 
     function appUpdated(cnsiGuid, refresh) {
-      return callAppTabs.apply(service, ['appUpdated', cnsiGuid, refresh]);
+      return cfClusterTabs.callTabs([service.tabs], 'appUpdated', cnsiGuid, refresh);
     }
 
     function appDeleting() {
-      return callAppTabs.apply(service, ['appDeleting']);
+      return cfClusterTabs.callTabs([service.tabs], 'appDeleting');
     }
 
     function appDeleted() {
-      return callAppTabs.apply(service, ['appDeleted']);
-    }
-
-    function _safeCallFunction(tab, func) {
-      return angular.isFunction(func) ? func.apply(tab, _.slice(arguments, 2)) : $q.resolve;
+      return cfClusterTabs.callTabs([service.tabs], 'appDeleted');
     }
 
   }

--- a/components/cloud-foundry/frontend/src/view/applications/application/application-tabs.service.js
+++ b/components/cloud-foundry/frontend/src/view/applications/application/application-tabs.service.js
@@ -8,13 +8,12 @@
   /**
    * @name cfApplicationTabs
    * @description Provides collection of configuration objects for tabs on the application page
-   * @param {object} $q - the Angular $q service
-   * @param {object} cfClusterTabs - the core cf tabs service
+   * @param {object} cfTabs - the core cf tabs service
    * @returns {object} The cfApplicationTabs object
    */
-  function ApplicationTabs(cfClusterTabs) {
+  function ApplicationTabs(cfTabs) {
     var service = {
-      tabs: cfClusterTabs.applicationTabs,
+      tabs: cfTabs.applicationTabs,
       clearState: clearState,
       appUpdated: appUpdated,
       appDeleting: appDeleting,
@@ -24,19 +23,19 @@
     return service;
 
     function clearState() {
-      return cfClusterTabs.callTabs([service.tabs], 'clearState');
+      return cfTabs.callTabs([service.tabs], 'clearState');
     }
 
     function appUpdated(cnsiGuid, refresh) {
-      return cfClusterTabs.callTabs([service.tabs], 'appUpdated', cnsiGuid, refresh);
+      return cfTabs.callTabs([service.tabs], 'appUpdated', cnsiGuid, refresh);
     }
 
     function appDeleting() {
-      return cfClusterTabs.callTabs([service.tabs], 'appDeleting');
+      return cfTabs.callTabs([service.tabs], 'appDeleting');
     }
 
     function appDeleted() {
-      return cfClusterTabs.callTabs([service.tabs], 'appDeleted');
+      return cfTabs.callTabs([service.tabs], 'appDeleted');
     }
 
   }

--- a/components/cloud-foundry/frontend/src/view/applications/application/application.html
+++ b/components/cloud-foundry/frontend/src/view/applications/application/application.html
@@ -5,19 +5,17 @@
     <actions-toolbar ready="appCtrl.ready" items="appCtrl.appActions"></actions-toolbar>
   </div>
 
-  <ul class="application-nav nav nav-tabs col-sm-12">
-    <li ng-repeat="feature in appCtrl.cfApplicationTabs.tabs | orderBy:'position'"
-        ui-sref-active="active" class="nav-item" ng-hide="feature.hide ? feature.hide() : feature.hide">
-      <a class="nav-link" ui-sref="{{feature.uiSref}}({guid: appCtrl.id})" translate>
-        {{ feature.label }}
-      </a>
-    </li>
+
+  <div class="application-tabs">
+    <cf-tabs tabs="appCtrl.cfApplicationTabs.tabs"></cf-tabs>
     <auto-update class="app-summary-auto-update"
                  update="appCtrl.autoUpdate.update"
                  interval="appCtrl.autoUpdate.interval"
                  run="appCtrl.autoUpdate.run"
                  popover="app.auto-update"></auto-update>
-  </ul>
+  </div>
+
+
 
   <div class="application-details col-sm-12">
     <div ui-view class="row"></div>

--- a/components/cloud-foundry/frontend/src/view/applications/application/application.scss
+++ b/components/cloud-foundry/frontend/src/view/applications/application/application.scss
@@ -36,13 +36,12 @@
   z-index: 1500;
 }
 
-.application-nav {
+.application-tabs {
 
   .app-summary-auto-update {
-    margin-top: 12px;
-    float: right;
-    margin-left: $console-unit-space / 2;
-    padding-top: 3px;
+    position: fixed;
+    right: 60px;
+    padding-top: 13px;
 
     > span {
       cursor: pointer;

--- a/components/cloud-foundry/frontend/src/view/applications/application/log-stream/log-stream.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/application/log-stream/log-stream.module.js
@@ -16,11 +16,14 @@
     });
   }
 
-  function registerAppTab(cfApplicationTabs) {
+  function registerAppTab($stateParams, cfApplicationTabs) {
     cfApplicationTabs.tabs.push({
       position: 2,
       hide: false,
       uiSref: 'cf.applications.application.log-stream',
+      uiSrefParam: function () {
+        return {guid: $stateParams.guid};
+      },
       label: 'app.app-info.app-tabs.log-stream.label'
     });
   }

--- a/components/cloud-foundry/frontend/src/view/applications/application/services/services.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/application/services/services.module.js
@@ -15,11 +15,14 @@
     });
   }
 
-  function registerAppTab(cfApplicationTabs) {
+  function registerAppTab($stateParams, cfApplicationTabs) {
     cfApplicationTabs.tabs.push({
       position: 3,
       hide: false,
       uiSref: 'cf.applications.application.services',
+      uiSrefParam: function () {
+        return {guid: $stateParams.guid};
+      },
       label: 'app.app-info.app-tabs.services.label'
     });
   }

--- a/components/cloud-foundry/frontend/src/view/applications/application/summary/summary.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/application/summary/summary.module.js
@@ -26,6 +26,9 @@
       position: 1,
       hide: false,
       uiSref: 'cf.applications.application.summary',
+      uiSrefParam: function () {
+        return {guid: $stateParams.guid};
+      },
       label: 'app.app-info.app-tabs.summary.label',
       appCreatedInstructions: [{
         id: 'new-app-deploy-cli',

--- a/components/cloud-foundry/frontend/src/view/applications/application/variables/variables.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/application/variables/variables.module.js
@@ -37,6 +37,9 @@
         return !canEditApp;
       },
       uiSref: 'cf.applications.application.variables',
+      uiSrefParam: function () {
+        return {guid: $stateParams.guid};
+      },
       label: 'app.app-info.app-tabs.variables.title',
       clearState: function () {
         canEditApp = undefined;

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/cluster-tabs.service.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/cluster-tabs.service.js
@@ -11,27 +11,29 @@
    * @param {object} $q - the Angular $q service
    * @returns {object} The cfClusterTabs service
    */
-  function ClusterTabs($q) {
-
-    var exampleTab = {
-      // position: 8,
-      // hide: function () {
-      //   var cnsiGuid = $stateParams.cnsiGuid;
-      //   var cnsiModel = modelManager.retrieve('app.model.serviceInstance.user');
-      //   return !cfUtilsService.hasSshAccess(cnsiModel.serviceInstances[cnsiGuid]);
-      // },
-      // uiSref: 'cf.applications.application.ssh',
-      // label: 'cf.app-ssh',
-    };
+  function ClusterTabs($q, $stateParams, modelManager) {
 
     var service = {
       clusterTabs: [ ],
       orgTabs: [],
       spaceTabs: [],
+      isAdmin: isAdmin,
       callTabs: callTabs
     };
 
     return service;
+
+    //TODO: Comment convienence + safety + timining (need on demand not available at register time)
+    function isAdmin() {
+      var consoleInfo = modelManager.retrieve('app.model.consoleInfo');
+      if (consoleInfo.info &&
+        consoleInfo.info.endpoints &&
+        consoleInfo.info.endpoints.cf[$stateParams.guid] &&
+        consoleInfo.info.endpoints.cf[$stateParams.guid].user) {
+        return consoleInfo.info.endpoints.cf[$stateParams.guid].user.admin;
+      }
+      return false;
+    }
 
     function callTabs(tabTypes, method) {
       var tasks = [];

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/cluster-tabs.service.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/cluster-tabs.service.js
@@ -9,11 +9,14 @@
    * @name cfClusterTabs
    * @description Provides collection of configuration objects for tabs on the cluster, org and space pages
    * @param {object} $q - the Angular $q service
+   * @param {object} $stateParams - the Angular $stateParams service
+   * @param {app.model.modelManager} modelManager - the application model manager
    * @returns {object} The cfClusterTabs service
    */
   function ClusterTabs($q, $stateParams, modelManager) {
 
-    var service = {
+    return {
+      applicationTabs: [],
       clusterTabs: [ ],
       orgTabs: [],
       spaceTabs: [],
@@ -21,9 +24,11 @@
       callTabs: callTabs
     };
 
-    return service;
-
-    //TODO: Comment convienence + safety + timining (need on demand not available at register time)
+    /**
+     * @function isAdmin
+     * @description Convenience method to safely fetch the cf user's admin status
+     * @returns {boolean} True if user connected to cluster is an admin
+     */
     function isAdmin() {
       var consoleInfo = modelManager.retrieve('app.model.consoleInfo');
       if (consoleInfo.info &&

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/cluster-tabs.service.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/cluster-tabs.service.js
@@ -1,0 +1,55 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('cloud-foundry.view.dashboard.cluster')
+    .factory('cfClusterTabs', ClusterTabs);
+
+  /**
+   * @name cfClusterTabs
+   * @description Provides collection of configuration objects for tabs on the cluster, org and space pages
+   * @param {object} $q - the Angular $q service
+   * @returns {object} The cfClusterTabs service
+   */
+  function ClusterTabs($q) {
+
+    var exampleTab = {
+      // position: 8,
+      // hide: function () {
+      //   var cnsiGuid = $stateParams.cnsiGuid;
+      //   var cnsiModel = modelManager.retrieve('app.model.serviceInstance.user');
+      //   return !cfUtilsService.hasSshAccess(cnsiModel.serviceInstances[cnsiGuid]);
+      // },
+      // uiSref: 'cf.applications.application.ssh',
+      // label: 'cf.app-ssh',
+    };
+
+    var service = {
+      clusterTabs: [ ],
+      orgTabs: [],
+      spaceTabs: [],
+      callTabs: callTabs
+    };
+
+    return service;
+
+    function callTabs(tabTypes, method) {
+      var tasks = [];
+      var args = Array.prototype.slice.call(arguments, 2);
+      _.forEach(tabTypes, function (tabType) {
+        _.forEach(tabType, function (tab) {
+          var promise = _safeCallFunction.apply(tab, [tab, tab[method]].concat(args));
+          tasks.push(promise || $q.resolve());
+        });
+      });
+
+      return $q.all(tasks);
+    }
+
+    function _safeCallFunction(tab, func) {
+      return angular.isFunction(func) ? func.apply(tab, _.slice(arguments, 2)) : $q.resolve;
+    }
+
+  }
+
+})();

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/buildpacks/buildpacks.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/buildpacks/buildpacks.module.js
@@ -21,11 +21,11 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.clusterTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.clusterTabs.push({
       position: 5,
       hide: function () {
-        return !cfClusterTabs.isAdmin();
+        return !cfTabs.isAdmin();
       },
       uiSref: 'endpoint.clusters.cluster.detail.buildPacks',
       uiSrefParam: _.noop,

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/buildpacks/buildpacks.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/buildpacks/buildpacks.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.detail.buildPacks', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.detail.buildPacks', {
@@ -17,6 +18,18 @@
           return 'endpoint.clusters.tiles';
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.clusterTabs.push({
+      position: 5,
+      hide: function () {
+        return !cfClusterTabs.isAdmin();
+      },
+      uiSref: 'endpoint.clusters.cluster.detail.buildPacks',
+      uiSrefParam: _.noop,
+      label: 'cf.cf-tabs.buildpacks'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/cluster-detail.html
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/cluster-detail.html
@@ -64,7 +64,7 @@
     </div>
   </div>
 
-  <cf-tabs tabs="clusterDetailController.cfClusterTabs.clusterTabs"></cf-tabs>
+  <cf-tabs tabs="clusterDetailController.cfTabs.clusterTabs"></cf-tabs>
 
   <ui-view></ui-view>
 </div>

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/cluster-detail.html
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/cluster-detail.html
@@ -64,29 +64,7 @@
     </div>
   </div>
 
+  <cf-tabs tabs="clusterDetailController.cfClusterTabs.clusterTabs"></cf-tabs>
 
-  <ul class="application-nav nav nav-tabs col-sm-12">
-    <li class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.detail.organizations" translate>cf.organisations</a>
-    </li>
-    <li class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.detail.users" translate>cf.users</a>
-    </li>
-    <li ng-if="clusterDetailController.isAdmin" class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.detail.firehose" translate>cf.cf-tabs.firehose</a>
-    </li>
-    <li ng-if="clusterDetailController.isAdmin" class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.detail.featureFlags" translate>cf.cf-tabs.feature-flags</a>
-    </li>
-    <li ng-if="clusterDetailController.isAdmin" class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.detail.buildPacks" translate>cf.cf-tabs.buildpacks</a>
-    </li>
-    <li ng-if="clusterDetailController.isAdmin" class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.detail.stacks" translate>cf.cf-tabs.stacks</a>
-    </li>
-    <li ng-if="clusterDetailController.isAdmin" class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.detail.securityGroups" translate>cf.cf-tabs.security-groups</a>
-    </li>
-  </ul>
   <ui-view></ui-view>
 </div>

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/cluster-detail.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/cluster-detail.module.js
@@ -29,7 +29,7 @@
 
   function ClusterDetailController($stateParams, $scope, $state, $q,
                                    modelManager, apiManager, appUtilsService, appClusterCliCommands,
-                                   modelUtils, cfOrganizationModel, cfUtilsService, cfClusterTabs) {
+                                   modelUtils, cfOrganizationModel, cfUtilsService, cfTabs) {
     var that = this;
     this.guid = $stateParams.guid;
     this.appClusterCliCommands = appClusterCliCommands;
@@ -41,7 +41,7 @@
     this.orgCount = $stateParams.orgCount;
     this.service = {};
     this.userService = {};
-    this.cfClusterTabs = cfClusterTabs;
+    this.cfTabs = cfTabs;
 
     var userServiceInstanceModel = modelManager.retrieve('app.model.serviceInstance.user');
     var userApi = apiManager.retrieve('cloud-foundry.api.Users');

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/cluster-detail.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/cluster-detail.module.js
@@ -29,7 +29,7 @@
 
   function ClusterDetailController($stateParams, $scope, $state, $q,
                                    modelManager, apiManager, appUtilsService, appClusterCliCommands,
-                                   modelUtils, cfOrganizationModel, cfUtilsService) {
+                                   modelUtils, cfOrganizationModel, cfUtilsService, cfClusterTabs) {
     var that = this;
     this.guid = $stateParams.guid;
     this.appClusterCliCommands = appClusterCliCommands;
@@ -41,6 +41,8 @@
     this.orgCount = $stateParams.orgCount;
     this.service = {};
     this.userService = {};
+    this.cfClusterTabs = cfClusterTabs;
+
     var userServiceInstanceModel = modelManager.retrieve('app.model.serviceInstance.user');
     var userApi = apiManager.retrieve('cloud-foundry.api.Users');
     var serviceInstanceModel = modelManager.retrieve('app.model.serviceInstance');

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/feature-flags/feature-flags.directive.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/feature-flags/feature-flags.directive.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.detail.featureFlags', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.detail.featureFlags', {
@@ -17,6 +18,18 @@
           return 'endpoint.clusters.tiles';
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.clusterTabs.push({
+      position: 4,
+      hide: function () {
+        return !cfClusterTabs.isAdmin();
+      },
+      uiSref: 'endpoint.clusters.cluster.detail.featureFlags',
+      uiSrefParam: _.noop,
+      label: 'cf.cf-tabs.feature-flags'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/feature-flags/feature-flags.directive.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/feature-flags/feature-flags.directive.js
@@ -21,11 +21,11 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.clusterTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.clusterTabs.push({
       position: 4,
       hide: function () {
-        return !cfClusterTabs.isAdmin();
+        return !cfTabs.isAdmin();
       },
       uiSref: 'endpoint.clusters.cluster.detail.featureFlags',
       uiSrefParam: _.noop,

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/firehose/cluster-detail.firehose.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/firehose/cluster-detail.firehose.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.detail.firehose', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.detail.firehose', {
@@ -17,6 +18,18 @@
           return 'endpoint.clusters.tiles';
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.clusterTabs.push({
+      position: 3,
+      hide: function () {
+        return !cfClusterTabs.isAdmin();
+      },
+      uiSref: 'endpoint.clusters.cluster.detail.firehose',
+      uiSrefParam: _.noop,
+      label: 'cf.cf-tabs.firehose'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/firehose/cluster-detail.firehose.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/firehose/cluster-detail.firehose.module.js
@@ -21,11 +21,11 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.clusterTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.clusterTabs.push({
       position: 3,
       hide: function () {
-        return !cfClusterTabs.isAdmin();
+        return !cfTabs.isAdmin();
       },
       uiSref: 'endpoint.clusters.cluster.detail.firehose',
       uiSrefParam: _.noop,

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/organizations/cluster-detail.organizations.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/organizations/cluster-detail.organizations.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.detail.organizations', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.detail.organizations', {
@@ -19,6 +20,16 @@
           }
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.clusterTabs.push({
+      position: 1,
+      hide: false,
+      uiSref: 'endpoint.clusters.cluster.detail.organizations',
+      uiSrefParam: _.noop,
+      label: 'cf.organisations'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/organizations/cluster-detail.organizations.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/organizations/cluster-detail.organizations.module.js
@@ -23,8 +23,8 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.clusterTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.clusterTabs.push({
       position: 1,
       hide: false,
       uiSref: 'endpoint.clusters.cluster.detail.organizations',

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/security-groups/security-groups.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/security-groups/security-groups.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.detail.securityGroups', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.detail.securityGroups', {
@@ -17,6 +18,18 @@
           return 'endpoint.clusters.tiles';
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.clusterTabs.push({
+      position: 7,
+      hide: function () {
+        return !cfClusterTabs.isAdmin();
+      },
+      uiSref: 'endpoint.clusters.cluster.detail.securityGroups',
+      uiSrefParam: _.noop,
+      label: 'cf.cf-tabs.security-groups'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/security-groups/security-groups.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/security-groups/security-groups.module.js
@@ -21,11 +21,11 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.clusterTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.clusterTabs.push({
       position: 7,
       hide: function () {
-        return !cfClusterTabs.isAdmin();
+        return !cfTabs.isAdmin();
       },
       uiSref: 'endpoint.clusters.cluster.detail.securityGroups',
       uiSrefParam: _.noop,

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/stacks/stacks.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/stacks/stacks.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.detail.stacks', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.detail.stacks', {
@@ -17,6 +18,18 @@
           return 'endpoint.clusters.tiles';
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.clusterTabs.push({
+      position: 6,
+      hide: function () {
+        return !cfClusterTabs.isAdmin();
+      },
+      uiSref: 'endpoint.clusters.cluster.detail.stacks',
+      uiSrefParam: _.noop,
+      label: 'cf.cf-tabs.stacks'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/stacks/stacks.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/stacks/stacks.module.js
@@ -21,11 +21,11 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.clusterTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.clusterTabs.push({
       position: 6,
       hide: function () {
-        return !cfClusterTabs.isAdmin();
+        return !cfTabs.isAdmin();
       },
       uiSref: 'endpoint.clusters.cluster.detail.stacks',
       uiSrefParam: _.noop,

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/users/cluster-detail.users.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/users/cluster-detail.users.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.detail.users', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.detail.users', {
@@ -17,6 +18,16 @@
           return 'endpoint.clusters.tiles';
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.clusterTabs.push({
+      position: 2,
+      hide: false,
+      uiSref: 'endpoint.clusters.cluster.detail.users',
+      uiSrefParam: _.noop,
+      label: 'cf.users'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/users/cluster-detail.users.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/detail/users/cluster-detail.users.module.js
@@ -21,8 +21,8 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.clusterTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.clusterTabs.push({
       position: 2,
       hide: false,
       uiSref: 'endpoint.clusters.cluster.detail.users',

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/cluster-organization-detail.html
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/cluster-organization-detail.html
@@ -20,7 +20,7 @@
     organization-names="clusterOrgDetailController.organizationNames">
   </organization-summary-tile>
 
-  <cf-tabs tabs="clusterOrgDetailController.cfClusterTabs.orgTabs"></cf-tabs>
+  <cf-tabs tabs="clusterOrgDetailController.cfTabs.orgTabs"></cf-tabs>
 
   <ui-view></ui-view>
 </div>

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/cluster-organization-detail.html
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/cluster-organization-detail.html
@@ -20,17 +20,7 @@
     organization-names="clusterOrgDetailController.organizationNames">
   </organization-summary-tile>
 
-  <ul class="application-nav nav nav-tabs col-sm-12">
-    <li class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.organization.detail.spaces" translate>
-        cf.org-info.space-tab-title
-      </a>
-    </li>
-    <li class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.organization.detail.users" translate>
-        cf.org-info.users-tab-title
-      </a>
-    </li>
-  </ul>
+  <cf-tabs tabs="clusterOrgDetailController.cfClusterTabs.orgTabs"></cf-tabs>
+
   <ui-view></ui-view>
 </div>

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/cluster-organization-detail.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/cluster-organization-detail.module.js
@@ -18,13 +18,13 @@
     });
   }
 
-  function ClusterOrgDetailController(appUtilsService, cfOrganizationModel, cfClusterTabs, $state, $stateParams, $q) {
+  function ClusterOrgDetailController(appUtilsService, cfOrganizationModel, cfTabs, $state, $stateParams, $q) {
     var vm = this;
 
     vm.clusterGuid = $stateParams.guid;
     vm.organizationGuid = $stateParams.organization;
     vm.organizationNames = [];
-    vm.cfClusterTabs = cfClusterTabs;
+    vm.cfTabs = cfTabs;
     vm.organization = organization;
 
     // Ensure the parent state is fully initialised before we start our own init

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/cluster-organization-detail.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/cluster-organization-detail.module.js
@@ -18,12 +18,13 @@
     });
   }
 
-  function ClusterOrgDetailController(appUtilsService, cfOrganizationModel, $state, $stateParams, $q) {
+  function ClusterOrgDetailController(appUtilsService, cfOrganizationModel, cfClusterTabs, $state, $stateParams, $q) {
     var vm = this;
 
     vm.clusterGuid = $stateParams.guid;
     vm.organizationGuid = $stateParams.organization;
     vm.organizationNames = [];
+    vm.cfClusterTabs = cfClusterTabs;
     vm.organization = organization;
 
     // Ensure the parent state is fully initialised before we start our own init

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/spaces/cluster-organization-detail-spaces.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/spaces/cluster-organization-detail-spaces.module.js
@@ -23,8 +23,8 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.orgTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.orgTabs.push({
       position: 1,
       hide: false,
       uiSref: 'endpoint.clusters.cluster.organization.detail.spaces',

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/spaces/cluster-organization-detail-spaces.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/spaces/cluster-organization-detail-spaces.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.organization.spaces', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.organization.detail.spaces', {
@@ -19,6 +20,16 @@
           return 'endpoint.clusters.cluster.detail.organizations';
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.orgTabs.push({
+      position: 1,
+      hide: false,
+      uiSref: 'endpoint.clusters.cluster.organization.detail.spaces',
+      uiSrefParam: _.noop,
+      label: 'cf.org-info.space-tab-title'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/users/organization-detail.users.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/users/organization-detail.users.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.organization.users', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.organization.detail.users', {
@@ -19,6 +20,16 @@
           return 'endpoint.clusters.cluster.detail.users';
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.orgTabs.push({
+      position: 2,
+      hide: false,
+      uiSref: 'endpoint.clusters.cluster.organization.detail.users',
+      uiSrefParam: _.noop,
+      label: 'cf.org-info.users-tab-title'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/users/organization-detail.users.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/detail/users/organization-detail.users.module.js
@@ -23,8 +23,8 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.orgTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.orgTabs.push({
       position: 2,
       hide: false,
       uiSref: 'endpoint.clusters.cluster.organization.detail.users',

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/applications/space-applications.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/applications/space-applications.module.js
@@ -21,8 +21,8 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.spaceTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.spaceTabs.push({
       position: 1,
       hide: false,
       uiSref: 'endpoint.clusters.cluster.organization.space.detail.applications',

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/applications/space-applications.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/applications/space-applications.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.organization.space.detail.applications', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.organization.space.detail.applications', {
@@ -17,6 +18,16 @@
           return 'endpoint.clusters.cluster.organization.detail.spaces';
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.spaceTabs.push({
+      position: 1,
+      hide: false,
+      uiSref: 'endpoint.clusters.cluster.organization.space.detail.applications',
+      uiSrefParam: _.noop,
+      label: 'cf.space-info.tabs.applications.title'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/cluster-space-detail.html
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/cluster-space-detail.html
@@ -15,27 +15,7 @@
                       space="clusterSpaceController.space()">
   </space-summary-tile>
 
-  <ul class="application-nav nav nav-tabs col-sm-12">
-    <li class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.organization.space.detail.applications" translate>
-        cf.space-info.tabs.applications.title
-      </a>
-    </li>
-    <li class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.organization.space.detail.services" translate>
-        cf.space-info.tabs.services.title
-      </a>
-    </li>
-    <li class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.organization.space.detail.routes" translate>
-        cf.space-info.tabs.routes.title
-      </a>
-    </li>
-    <li class="nav-item" ui-sref-active="active">
-      <a class="nav-link" ui-sref="endpoint.clusters.cluster.organization.space.detail.users" translate>
-        cf.space-info.tabs.users.title
-      </a>
-    </li>
-  </ul>
+  <cf-tabs tabs="clusterSpaceController.cfClusterTabs.spaceTabs"></cf-tabs>
+
   <ui-view></ui-view>
 </div>

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/cluster-space-detail.html
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/cluster-space-detail.html
@@ -15,7 +15,7 @@
                       space="clusterSpaceController.space()">
   </space-summary-tile>
 
-  <cf-tabs tabs="clusterSpaceController.cfClusterTabs.spaceTabs"></cf-tabs>
+  <cf-tabs tabs="clusterSpaceController.cfTabs.spaceTabs"></cf-tabs>
 
   <ui-view></ui-view>
 </div>

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/cluster-space-detail.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/cluster-space-detail.module.js
@@ -19,7 +19,7 @@
     });
   }
 
-  function ClusterSpaceController($q, $state, $stateParams, modelManager, appUtilsService) {
+  function ClusterSpaceController($q, $state, $stateParams, modelManager, appUtilsService, cfClusterTabs) {
     var vm = this;
 
     vm.space = space;
@@ -28,6 +28,7 @@
     vm.organizationGuid = $stateParams.organization;
     vm.spaceGuid = $stateParams.space;
     vm.stateInitialised = false;
+    vm.cfClusterTabs = cfClusterTabs;
 
     var spaceModel = modelManager.retrieve('cloud-foundry.model.space');
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/cluster-space-detail.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/cluster-space-detail.module.js
@@ -19,7 +19,7 @@
     });
   }
 
-  function ClusterSpaceController($q, $state, $stateParams, modelManager, appUtilsService, cfClusterTabs) {
+  function ClusterSpaceController($q, $state, $stateParams, modelManager, appUtilsService, cfTabs) {
     var vm = this;
 
     vm.space = space;
@@ -28,7 +28,7 @@
     vm.organizationGuid = $stateParams.organization;
     vm.spaceGuid = $stateParams.space;
     vm.stateInitialised = false;
-    vm.cfClusterTabs = cfClusterTabs;
+    vm.cfTabs = cfTabs;
 
     var spaceModel = modelManager.retrieve('cloud-foundry.model.space');
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/routes/space-routes.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/routes/space-routes.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.organization.space.detail.routes', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.organization.space.detail.routes', {
@@ -17,6 +18,16 @@
           return 'endpoint.clusters.cluster.organization.detail.spaces';
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.spaceTabs.push({
+      position: 3,
+      hide: false,
+      uiSref: 'endpoint.clusters.cluster.organization.space.detail.routes',
+      uiSrefParam: _.noop,
+      label: 'cf.space-info.tabs.routes.title'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/routes/space-routes.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/routes/space-routes.module.js
@@ -21,8 +21,8 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.spaceTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.spaceTabs.push({
       position: 3,
       hide: false,
       uiSref: 'endpoint.clusters.cluster.organization.space.detail.routes',

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/services/space-services.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/services/space-services.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.organization.space.detail.services', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.organization.space.detail.services', {
@@ -20,7 +21,17 @@
     });
   }
 
-  function SpaceServicesController($scope, $state, $stateParams, $q, $filter, modelManager, cfServiceInstanceService,
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.spaceTabs.push({
+      position: 2,
+      hide: false,
+      uiSref: 'endpoint.clusters.cluster.organization.space.detail.services',
+      uiSrefParam: _.noop,
+      label: 'cf.space-info.tabs.services.title'
+    });
+  }
+
+  function SpaceServicesController($scope, $state, $stateParams, $q, modelManager, cfServiceInstanceService,
                                    appUtilsService) {
     var vm = this;
 

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/services/space-services.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/services/space-services.module.js
@@ -21,8 +21,8 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.spaceTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.spaceTabs.push({
       position: 2,
       hide: false,
       uiSref: 'endpoint.clusters.cluster.organization.space.detail.services',

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/users/space-detail.users.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/users/space-detail.users.module.js
@@ -21,8 +21,8 @@
     });
   }
 
-  function registerTab(cfClusterTabs) {
-    cfClusterTabs.spaceTabs.push({
+  function registerTab(cfTabs) {
+    cfTabs.spaceTabs.push({
       position: 4,
       hide: false,
       uiSref: 'endpoint.clusters.cluster.organization.space.detail.users',

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/users/space-detail.users.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/users/space-detail.users.module.js
@@ -3,7 +3,8 @@
 
   angular
     .module('cloud-foundry.view.dashboard.cluster.organization.space.detail.users', [])
-    .config(registerRoute);
+    .config(registerRoute)
+    .run(registerTab);
 
   function registerRoute($stateProvider) {
     $stateProvider.state('endpoint.clusters.cluster.organization.space.detail.users', {
@@ -17,6 +18,16 @@
           return 'endpoint.clusters.cluster.organization.detail.users';
         }
       }
+    });
+  }
+
+  function registerTab(cfClusterTabs) {
+    cfClusterTabs.spaceTabs.push({
+      position: 4,
+      hide: false,
+      uiSref: 'endpoint.clusters.cluster.organization.space.detail.users',
+      uiSrefParam: _.noop,
+      label: 'cf.space-info.tabs.users.title'
     });
   }
 

--- a/components/cloud-foundry/frontend/src/view/util/cf-tabs/cf-tabs.directive.js
+++ b/components/cloud-foundry/frontend/src/view/util/cf-tabs/cf-tabs.directive.js
@@ -1,0 +1,34 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('cloud-foundry.view')
+    .directive('cfTabs', cfTabs);
+
+  /**
+   * @name cfTabs
+   * @returns {object} The cfTabs directive definition object
+   */
+  function cfTabs() {
+    return {
+      bindToController: {
+        tabs: '='
+      },
+      controller: CFTabs,
+      controllerAs: 'cfTabs',
+      templateUrl: 'plugins/cloud-foundry/view/util/cf-tabs/cf-tabs.html'
+    };
+  }
+
+  /**
+   * @name CFTabs
+   * @constructor
+   * @param {object} $stateParams - the ui-router $stateParams service
+   * @param {object} modelManager - the model manager service
+   * @param {app.framework.widgets.frameworkDetailView} frameworkDetailView frameworkDetailView
+   */
+  function CFTabs($stateParams, modelManager, frameworkDetailView) {
+    var vm = this;
+
+  }
+})();

--- a/components/cloud-foundry/frontend/src/view/util/cf-tabs/cf-tabs.directive.js
+++ b/components/cloud-foundry/frontend/src/view/util/cf-tabs/cf-tabs.directive.js
@@ -11,24 +11,11 @@
    */
   function cfTabs() {
     return {
-      bindToController: {
+      scope: {
         tabs: '='
       },
-      controller: CFTabs,
-      controllerAs: 'cfTabs',
       templateUrl: 'plugins/cloud-foundry/view/util/cf-tabs/cf-tabs.html'
     };
   }
 
-  /**
-   * @name CFTabs
-   * @constructor
-   * @param {object} $stateParams - the ui-router $stateParams service
-   * @param {object} modelManager - the model manager service
-   * @param {app.framework.widgets.frameworkDetailView} frameworkDetailView frameworkDetailView
-   */
-  function CFTabs($stateParams, modelManager, frameworkDetailView) {
-    var vm = this;
-
-  }
 })();

--- a/components/cloud-foundry/frontend/src/view/util/cf-tabs/cf-tabs.html
+++ b/components/cloud-foundry/frontend/src/view/util/cf-tabs/cf-tabs.html
@@ -1,0 +1,8 @@
+<ul class="application-nav nav nav-tabs col-sm-12">
+  <li ng-repeat="tab in cfTabs.tabs | orderBy:'position'"
+      ui-sref-active="active" class="nav-item" ng-hide="tab.hide ? tab.hide() : tab.hide">
+    <a class="nav-link" ui-sref="{{tab.uiSref}}(tab.uiSrefParam())" translate>
+      {{ tab.label }}
+    </a>
+  </li>
+</ul>

--- a/components/cloud-foundry/frontend/src/view/util/cf-tabs/cf-tabs.html
+++ b/components/cloud-foundry/frontend/src/view/util/cf-tabs/cf-tabs.html
@@ -1,5 +1,5 @@
 <ul class="application-nav nav nav-tabs col-sm-12">
-  <li ng-repeat="tab in cfTabs.tabs | orderBy:'position'"
+  <li ng-repeat="tab in tabs | orderBy:'position'"
       ui-sref-active="active" class="nav-item" ng-hide="tab.hide ? tab.hide() : tab.hide">
     <a class="nav-link" ui-sref="{{tab.uiSref}}(tab.uiSrefParam())" translate>
       {{ tab.label }}

--- a/components/cloud-foundry/frontend/test/unit/view/dashboard/cluster/organization/space/cluster-organization-detail.module.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/dashboard/cluster/organization/space/cluster-organization-detail.module.spec.js
@@ -16,6 +16,7 @@
 
       var appUtilsService = $injector.get('appUtilsService');
       var cfOrganizationModel = $injector.get('cfOrganizationModel');
+      var cfClusterTabs = $injector.get('cfClusterTabs');
 
       var $state = $injector.get('$state');
       var $stateParams = $injector.get('$stateParams');
@@ -24,7 +25,7 @@
       var $q = $injector.get('$q');
 
       var ClusterOrgDetailController = $state.get('endpoint.clusters.cluster.organization.detail').controller;
-      $controller = new ClusterOrgDetailController(appUtilsService, cfOrganizationModel, $state, $stateParams, $q);
+      $controller = new ClusterOrgDetailController(appUtilsService, cfOrganizationModel, cfClusterTabs, $state, $stateParams, $q);
     }));
 
     afterEach(function () {

--- a/components/cloud-foundry/frontend/test/unit/view/dashboard/cluster/organization/space/cluster-organization-detail.module.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/dashboard/cluster/organization/space/cluster-organization-detail.module.spec.js
@@ -16,7 +16,7 @@
 
       var appUtilsService = $injector.get('appUtilsService');
       var cfOrganizationModel = $injector.get('cfOrganizationModel');
-      var cfClusterTabs = $injector.get('cfClusterTabs');
+      var cfTabs = $injector.get('cfTabs');
 
       var $state = $injector.get('$state');
       var $stateParams = $injector.get('$stateParams');
@@ -25,7 +25,7 @@
       var $q = $injector.get('$q');
 
       var ClusterOrgDetailController = $state.get('endpoint.clusters.cluster.organization.detail').controller;
-      $controller = new ClusterOrgDetailController(appUtilsService, cfOrganizationModel, cfClusterTabs, $state, $stateParams, $q);
+      $controller = new ClusterOrgDetailController(appUtilsService, cfOrganizationModel, cfTabs, $state, $stateParams, $q);
     }));
 
     afterEach(function () {

--- a/components/cloud-foundry/frontend/test/unit/view/dashboard/cluster/organization/space/space-services.module.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/dashboard/cluster/organization/space/space-services.module.spec.js
@@ -3,7 +3,7 @@
 
   describe('cluster space detail (services) module', function () {
 
-    var $controller, $httpBackend, $scope, $state, $stateParams, $q, $filter, modelManager,
+    var $controller, $httpBackend, $scope, $state, $stateParams, $q, modelManager,
       cfServiceInstanceService, appUtilsService;
 
     beforeEach(module('templates'));
@@ -40,7 +40,6 @@
       $stateParams.organization = organizationGuid;
       $stateParams.space = spaceGuid;
       $q = $injector.get('$q');
-      $filter = $injector.get('$filter');
       modelManager = $injector.get('modelManager');
       cfServiceInstanceService = $injector.get('cfServiceInstanceService');
       appUtilsService = $injector.get('appUtilsService');
@@ -55,7 +54,7 @@
       _.set(spaceModel, 'spaces.' + clusterGuid + '.' + spaceGuid, space);
 
       var SpaceServicesController = $state.get('endpoint.clusters.cluster.organization.space.detail.services').controller;
-      $controller = new SpaceServicesController($scope, $state, $stateParams, $q, $filter, modelManager,
+      $controller = new SpaceServicesController($scope, $state, $stateParams, $q, modelManager,
         cfServiceInstanceService, appUtilsService);
     }
 


### PR DESCRIPTION
- Create directive to display tabs generically and use in cf apps, cluster, org and space pages
- Store tab collections for each page in central location
- Dynamically add to tab collections