### PR TITLE
Point PGDATA to the root of the volume mount

### DIFF
--- a/deploy/kubernetes/console/templates/deployment.yaml
+++ b/deploy/kubernetes/console/templates/deployment.yaml
@@ -167,7 +167,7 @@ spec:
         - name: POSTGRES_PASSWORD_FILE
           value: /etc/secrets/stolon
         - name: PGDATA
-          value: /stolon-data/postgres
+          value: /stolon-data
         - name: HTTP_PROXY
         {{- if .Values.httpProxy }}
           value: {{.Values.httpProxy}}


### PR DESCRIPTION
At least with Kubernetes 1.6 a hostPath volume mount will be owned by root and have 750 permissions.

The docker-entrypoint.sh script will try to assign ownership to the postgres user:

	mkdir -p "$PGDATA"
	chmod 700 "$PGDATA"
	chown -R postgres "$PGDATA"

But this is insufficient if PGDATA points to a subdirectory of the mount directory since the postgres user doesn't have "execute" permission and therefore cannot reach the data directory.