### PR TITLE
Enable Console do be deployed in K8s clusters without shared storage provisioners

### DIFF
--- a/deploy/Dockerfile.bk-preflight.dev
+++ b/deploy/Dockerfile.bk-preflight.dev
@@ -1,0 +1,13 @@
+FROM alpine:latest
+
+RUN apk update && \
+    apk add ca-certificates openssl git &&\
+    mkdir -p /srv
+
+WORKDIR /srv
+COPY outputs/* /srv/
+COPY /deploy/db/scripts/run-preflight-job.sh /run-preflight-job.sh
+COPY dev-certs dev-certs
+RUN chmod +x portal-proxy
+EXPOSE 443
+CMD ["sh", "-c", "/run-preflight-job.sh; /srv/portal-proxy"]

--- a/deploy/db/scripts/run-postflight-job.k8s.sh
+++ b/deploy/db/scripts/run-postflight-job.k8s.sh
@@ -75,4 +75,12 @@ rm /$UPGRADE_VOLUME/$UPGRADE_LOCK_FILENAME || true
 
 echo "Removed the upgrade lock file."
 
-exit 0
+# If DO_NOT_QUIT is set, don't quit script
+# This is only used in toy kubernetes deployments with no shared volume 
+if [ "${DO_NOT_QUIT:-false}" = "false" ]; then
+    echo "Running in shared volume mode, exiting..."
+    exit 0
+else
+    echo "Running in 'DO NOT QUIT' mode"
+    while true; do echo ''; sleep 5; done   
+fi

--- a/deploy/db/scripts/run-preflight-job.sh
+++ b/deploy/db/scripts/run-preflight-job.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # Step 1 - Set the lock file on the shared volume

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -142,8 +142,7 @@ For instance to use the storage class `persistent` to deploy Console persistent 
 
 ```
 ---
-persistence:
-    storageClass: persistent
+storageClass: persistent
 ```
 
 Run Helm with the override:
@@ -151,7 +150,9 @@ Run Helm with the override:
 helm install -f override.yaml stratos-ui/console
 ```
 #### Create default Storage Class
-Alternatively, you can configure a storage class with `storageclass.kubernetes.io/is-default-class` set to `true`. For instance the following storage class will be declared as the default. Save the file to `storageclass.yaml`
+Alternatively, you can configure a storage class with `storageclass.kubernetes.io/is-default-class` set to `true`. For instance the following storage class will be declared as the default. If you don't have the `hostpath` provisioner available in your local cluster, please follow the instructions on [link] (https://github.com/kubernetes-incubator/external-storage/tree/master/docs/demo/hostpath-provisioner), to deploy one.
+
+If the hostpath provisioner is available, save the file to `storageclass.yaml`
 
 ```
 ---
@@ -161,7 +162,7 @@ metadata:
   name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-provisioner: kubernetes.io/host-path
+provisioner: kubernetes.io/host-path # Or whatever the local hostpath provisioner is called
 ```
 
 To create it in your kubernetes cluster, execute the following.

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -41,9 +41,13 @@ helm install stratos-ui/console --namespace=console --name my-console
 
 > You can change the namespace (--namespace) and the release name (--name) to values of your choice.
 
-This will create a Console instance named `my-console` in a namespace called `console` in your Kubernetes cluster.
+This will create a Console instance named `my-console` in a namespace called `console` in your Kubernetes cluster. If you are deploying into a cluster that is not configured with a dynamic storage provisioner like `glusterfs` or `ceph`. You should specify the `noShared` override when installing the chart. 
 
-You should now be able to access the Console in a web browser by following [the instructions](#accessing-the-console) below.
+```
+helm install --set noShared=true stratos-ui/console --namespace=console --name my-console
+```
+
+After the install, you should be able to access the Console in a web browser by following [the instructions](#accessing-the-console) below.
 
 ## Deploying using the GitHub repository
 

--- a/deploy/kubernetes/build.sh
+++ b/deploy/kubernetes/build.sh
@@ -192,6 +192,8 @@ function buildProxy {
   echo
   echo "-- Build & publish the runtime container image for the Console Proxy"
   buildAndPublishImage stratos-proxy deploy/Dockerfile.bk.dev ${STRATOS_UI_PATH}
+  # Build merged preflight & proxy image, used when deploying into multi-node k8s cluster without a shared storage backend
+  buildAndPublishImage stratos-proxy-noshared deploy/Dockerfile.bk-preflight.dev ${STRATOS_UI_PATH}
 }
 
 function buildPostgres {
@@ -276,7 +278,7 @@ buildPreflightJob
 buildPostflightJob
 buildUI
 
-if [ -z ${CONCOURSE_BUILD} ]; then
+if [ ${CONCOURSE_BUILD:-"not-set"} == "not-set" ]; then
   # Patch Values.yaml file
   cp values.yaml.tmpl values.yaml
   sed -i -e 's/CONSOLE_VERSION/'"${TAG}"'/g' values.yaml
@@ -292,7 +294,7 @@ echo "Build complete...."
 echo "Registry: ${DOCKER_REGISTRY}"
 echo "Org: ${DOCKER_ORG}"
 echo "Tag: ${TAG}"
-if [ -z ${CONCOURSE_BUILD} ]; then
+if [ ${CONCOURSE_BUILD:-"not-set"} == "not-set" ]; then
   echo "To deploy using Helm, execute the following: "
   echo "helm install console -f values.yaml --namespace console --name my-console"
 fi

--- a/deploy/kubernetes/console/templates/deployment.yaml
+++ b/deploy/kubernetes/console/templates/deployment.yaml
@@ -6,11 +6,11 @@ metadata:
  labels:
    app: "{{ .Release.Name }}"
  annotations:
-  {{- if .Values.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-  {{- else }}
+  {{ if .Values.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.storageClass | quote }}
+  {{ else }}
     volume.alpha.kubernetes.io/storage-class: default
-  {{- end }}
+  {{ end }}
 spec:
  accessModes:
    - ReadWriteMany
@@ -59,8 +59,67 @@ spec:
         - containerPort: 443
           name: https
           protocol: TCP
+     {{ if .Values.noShared }}
+      - image: {{.Values.dockerRegistry}}/{{.Values.dockerOrg}}/{{.Values.images.postflight}}:{{.Values.consoleVersion}}
+        name: "{{ .Release.Name }}-postflight"
+        env:
+        - name: PGSQL_HOST
+          value: "{{ .Release.Name }}-postgres-int"
+        - name: PGSQL_PORT
+          value: "5432"
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD_FILE
+          value: /etc/secrets/stolon
+        - name: PGSQL_DATABASE
+          value: console-db
+        - name: PGSQL_USER
+          value: console
+        - name: PGSQL_PASSWORDFILE
+          value: /etc/secrets/pgsql-password
+        - name: PGSQL_SSL_MODE
+          value: disable
+        - name: PGCONNECT_TIMEOUT
+          value: "10"
+        - name: DO_NOT_QUIT
+          value: "true"
+        - name: UPGRADE_VOLUME
+          value: "{{ .Release.Name }}-upgrade-volume"
+        - name: UPGRADE_LOCK_FILENAME
+          value: upgrade.lock
+        - name: HTTP_PROXY
+        {{ if .Values.httpProxy }}
+          value: {{.Values.httpProxy}}
+        {{ end }}
+        - name: HTTPS_PROXY
+        {{ if .Values.httpsProxy }}
+          value: {{.Values.httpsProxy}}
+        {{ end }}
+        - name: NO_PROXY
+        {{ if .Values.noProxy }}
+          value: {{.Values.noProxy}}
+        {{ end }}
+        - name: FTP_PROXY
+        {{ if .Values.ftpProxy }}
+          value: {{.Values.ftpProxy}}
+        {{ end }}
+        - name: SOCKS_PROXY
+        {{ if .Values.socksProxy }}  
+          value: {{.Values.socksProxy}}
+        {{ end }}
+        volumeMounts:
+          - mountPath: "/{{ .Release.Name }}-upgrade-volume"
+            name: "{{ .Release.Name }}-upgrade-volume"
+          - mountPath: /etc/secrets/
+            name: "{{ .Release.Name }}-secret"
+     {{ end }}
+     {{ if not .Values.noShared }}
       - image: {{.Values.dockerRegistry}}/{{.Values.dockerOrg}}/{{.Values.images.proxy}}:{{.Values.consoleVersion}}
         name: proxy
+     {{ else }}
+      - image: {{.Values.dockerRegistry}}/{{.Values.dockerOrg}}/{{.Values.images.proxyNoShared}}:{{.Values.consoleVersion}}
+        name: proxy
+     {{ end }}
         env:
         - name: PGSQL_USER
           value: console
@@ -100,25 +159,25 @@ spec:
         - name: ENCRYPTION_KEY_FILENAME
           value: key
         - name: HTTP_PROXY
-        {{- if .Values.httpProxy }}
+        {{ if .Values.httpProxy }}
           value: {{.Values.httpProxy}}
-        {{- end }}
+        {{ end }}
         - name: HTTPS_PROXY
-        {{- if .Values.httpsProxy }}
+        {{ if .Values.httpsProxy }}
           value: {{.Values.httpsProxy}}
-        {{- end }}
+        {{ end }}
         - name: NO_PROXY
-        {{- if .Values.noProxy }}
+        {{ if .Values.noProxy }}
           value: {{.Values.noProxy}}
-        {{- end }}
+        {{ end }}
         - name: FTP_PROXY
-        {{- if .Values.ftpProxy }}
+        {{ if .Values.ftpProxy }}
           value: {{.Values.ftpProxy}}
-        {{- end }}
+        {{ end }}
         - name: SOCKS_PROXY
-        {{- if .Values.socksProxy }}
+        {{ if .Values.socksProxy }}
           value: {{.Values.socksProxy}}
-        {{- end }}
+        {{ end }}
         ports:
         - containerPort: 3003
           name: proxy
@@ -169,25 +228,25 @@ spec:
         - name: PGDATA
           value: /stolon-data/postgres
         - name: HTTP_PROXY
-        {{- if .Values.httpProxy }}
+        {{ if .Values.httpProxy }}
           value: {{.Values.httpProxy}}
-        {{- end }}
+        {{ end }}
         - name: HTTPS_PROXY
-        {{- if .Values.httpsProxy }}
+        {{ if .Values.httpsProxy }}
           value: {{.Values.httpsProxy}}
-        {{- end }}
+        {{ end }}
         - name: NO_PROXY
-        {{- if .Values.noProxy }}
+        {{ if .Values.noProxy }}
           value: {{.Values.noProxy}}
-        {{- end }}
+        {{ end }}
         - name: FTP_PROXY
-        {{- if .Values.ftpProxy }}
+        {{ if .Values.ftpProxy }}
           value: {{.Values.ftpProxy}}
-        {{- end }}
+        {{ end }}
         - name: SOCKS_PROXY
-        {{- if .Values.socksProxy }}
+        {{ if .Values.socksProxy }}
           value: {{.Values.socksProxy}}
-        {{- end }}
+        {{ end }}
         volumeMounts:
         - mountPath: /stolon-data
           name: "{{ .Release.Name }}-postgres-volume"

--- a/deploy/kubernetes/console/templates/deployment.yaml
+++ b/deploy/kubernetes/console/templates/deployment.yaml
@@ -6,11 +6,11 @@ metadata:
  labels:
    app: "{{ .Release.Name }}"
  annotations:
-  {{ if .Values.storageClass }}
+  {{- if .Values.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.storageClass | quote }}
-  {{ else }}
+  {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
-  {{ end }}
+  {{- end }}
 spec:
  accessModes:
    - ReadWriteMany
@@ -59,7 +59,7 @@ spec:
         - containerPort: 443
           name: https
           protocol: TCP
-     {{ if .Values.noShared }}
+     {{- if .Values.noShared }}
       - image: {{.Values.dockerRegistry}}/{{.Values.dockerOrg}}/{{.Values.images.postflight}}:{{.Values.consoleVersion}}
         name: "{{ .Release.Name }}-postflight"
         env:
@@ -88,38 +88,38 @@ spec:
         - name: UPGRADE_LOCK_FILENAME
           value: upgrade.lock
         - name: HTTP_PROXY
-        {{ if .Values.httpProxy }}
+        {{- if .Values.httpProxy }}
           value: {{.Values.httpProxy}}
-        {{ end }}
+        {{- end }}
         - name: HTTPS_PROXY
-        {{ if .Values.httpsProxy }}
+        {{- if .Values.httpsProxy }}
           value: {{.Values.httpsProxy}}
-        {{ end }}
+        {{- end }}
         - name: NO_PROXY
-        {{ if .Values.noProxy }}
+        {{- if .Values.noProxy }}
           value: {{.Values.noProxy}}
-        {{ end }}
+        {{- end }}
         - name: FTP_PROXY
-        {{ if .Values.ftpProxy }}
+        {{- if .Values.ftpProxy }}
           value: {{.Values.ftpProxy}}
-        {{ end }}
+        {{- end }}
         - name: SOCKS_PROXY
-        {{ if .Values.socksProxy }}  
+        {{- if .Values.socksProxy }}  
           value: {{.Values.socksProxy}}
-        {{ end }}
+        {{- end }}
         volumeMounts:
           - mountPath: "/{{ .Release.Name }}-upgrade-volume"
             name: "{{ .Release.Name }}-upgrade-volume"
           - mountPath: /etc/secrets/
             name: "{{ .Release.Name }}-secret"
-     {{ end }}
-     {{ if not .Values.noShared }}
+     {{- end }}
+     {{- if not .Values.noShared }}
       - image: {{.Values.dockerRegistry}}/{{.Values.dockerOrg}}/{{.Values.images.proxy}}:{{.Values.consoleVersion}}
         name: proxy
-     {{ else }}
+     {{- else }}
       - image: {{.Values.dockerRegistry}}/{{.Values.dockerOrg}}/{{.Values.images.proxyNoShared}}:{{.Values.consoleVersion}}
         name: proxy
-     {{ end }}
+     {{- end }}
         env:
         - name: PGSQL_USER
           value: console
@@ -159,25 +159,25 @@ spec:
         - name: ENCRYPTION_KEY_FILENAME
           value: key
         - name: HTTP_PROXY
-        {{ if .Values.httpProxy }}
+        {{- if .Values.httpProxy }}
           value: {{.Values.httpProxy}}
-        {{ end }}
+        {{- end }}
         - name: HTTPS_PROXY
-        {{ if .Values.httpsProxy }}
+        {{- if .Values.httpsProxy }}
           value: {{.Values.httpsProxy}}
-        {{ end }}
+        {{- end }}
         - name: NO_PROXY
-        {{ if .Values.noProxy }}
+        {{- if .Values.noProxy }}
           value: {{.Values.noProxy}}
-        {{ end }}
+        {{- end }}
         - name: FTP_PROXY
-        {{ if .Values.ftpProxy }}
+        {{- if .Values.ftpProxy }}
           value: {{.Values.ftpProxy}}
-        {{ end }}
+        {{- end }}
         - name: SOCKS_PROXY
-        {{ if .Values.socksProxy }}
+        {{- if .Values.socksProxy }}
           value: {{.Values.socksProxy}}
-        {{ end }}
+        {{- end }}
         ports:
         - containerPort: 3003
           name: proxy
@@ -228,25 +228,25 @@ spec:
         - name: PGDATA
           value: /stolon-data/postgres
         - name: HTTP_PROXY
-        {{ if .Values.httpProxy }}
+        {{- if .Values.httpProxy }}
           value: {{.Values.httpProxy}}
-        {{ end }}
+        {{- end }}
         - name: HTTPS_PROXY
-        {{ if .Values.httpsProxy }}
+        {{- if .Values.httpsProxy }}
           value: {{.Values.httpsProxy}}
-        {{ end }}
+        {{- end }}
         - name: NO_PROXY
-        {{ if .Values.noProxy }}
+        {{- if .Values.noProxy }}
           value: {{.Values.noProxy}}
-        {{ end }}
+        {{- end }}
         - name: FTP_PROXY
-        {{ if .Values.ftpProxy }}
+        {{- if .Values.ftpProxy }}
           value: {{.Values.ftpProxy}}
-        {{ end }}
+        {{- end }}
         - name: SOCKS_PROXY
-        {{ if .Values.socksProxy }}
+        {{- if .Values.socksProxy }}
           value: {{.Values.socksProxy}}
-        {{ end }}
+        {{- end }}
         volumeMounts:
         - mountPath: /stolon-data
           name: "{{ .Release.Name }}-postgres-volume"

--- a/deploy/kubernetes/console/templates/post-install.yaml
+++ b/deploy/kubernetes/console/templates/post-install.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.noShared }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -74,3 +75,4 @@ spec:
        - name: "{{ .Release.Name }}-secret"
          secret:
            secretName: "{{ .Release.Name }}-secret"
+{{- end }}

--- a/deploy/kubernetes/console/templates/pre-install.yaml
+++ b/deploy/kubernetes/console/templates/pre-install.yaml
@@ -7,7 +7,7 @@ metadata:
     app:  "{{ .Release.Name }}"
   annotations:
   {{- if .Values.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.storageClass | quote }}
   {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}
@@ -28,7 +28,7 @@ metadata:
     app:  "{{ .Release.Name }}"
   annotations:
   {{- if .Values.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.storageClass | quote }}
   {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}
@@ -40,6 +40,8 @@ spec:
   resources:
     requests:
       storage: 1Mi
+
+{{- if  not .Values.noShared }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -116,3 +118,4 @@ spec:
         - sh
         - -c
         - "kubectl delete job --namespace {{ .Release.Namespace }} -l app={{ .Release.Name }}"
+{{- end }}


### PR DESCRIPTION
Adds an override variable `noShared`, which can be specified when installing into a cluster that doesn't have a dynamic storage provisioner available and uses the `hostpath` provisioner.

This override causes the pre-flight and postflight jobs to in the Console pod. `Postflight` runs as a separate container, while preflight runs before the proxy is started.

To deploy using `noShared` mode, either specify an overrides file, or when executing a helm-install:

```
helm install --set noShared=true console --namespace console
```