### PR TITLE
Force the console cf app to use the cflinuxfs2 stack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,4 @@ applications:
   timeout: 180
   buildpack: https://github.com/cloudfoundry-incubator/multi-buildpack
   health-check-type: port
+  stack: cflinuxfs2


### PR DESCRIPTION
- We use a multi-buildpack to build the console
- The cf multi-buildpack does not support system buildpacks, in the scf world these would be compatible with scf's opensuse42 stack
- So we specify the use of standard cf buildpaForce the console cf app to use the cflinuxfs2 stack
- We use a multi-buildpack to build the console
- The cf multi-buildpack does not support system buildpacks, in the scf world these would be compatible with scf's opensuse42 stack
- So we specify the use of standard cf buildpacks, which are incompatible with opensuse42, so need to force the use of cflinuxfs2
- We've also tried setting the scf buildpacks in the multo-buildpack however get an error. We should look into this and once resolved apply that change and revert this PR. Alternatively get the multi-buildpack to support system buildpacks.cks, which are incompatible with opensuse42, so need to force the use of cflinuxfs2.