### PR TITLE
Fix issue where previously selected language was not shown on landing page

### DIFF
--- a/components/app-core/frontend/src/view/landing-page/landing-page.directive.js
+++ b/components/app-core/frontend/src/view/landing-page/landing-page.directive.js
@@ -25,18 +25,21 @@
     };
   }
 
-  function landingPageController($scope, $translate, languageService) {
+  function landingPageController($scope, languageService) {
     var vm = this;
     vm.languageService = languageService;
     vm.languageOptions = vm.languageService.getAll();
-    vm.currentLanguage = $translate.use();
-    $scope.$watch(function () {
-      return vm.currentLanguage;
-    }, function (newValue, oldValue) {
-      if (newValue !== oldValue) {
-        languageService.setLocale(newValue);
-      }
+    languageService.getLocale(true).then(function (locale) {
+      vm.currentLanguage = locale;
 
+      $scope.$watch(function () {
+        return vm.currentLanguage;
+      }, function (newValue, oldValue) {
+        if (newValue !== oldValue) {
+          languageService.setLocale(newValue);
+        }
+      });
     });
+
   }
 })();


### PR DESCRIPTION
- We'd fetch the lang before previously selected lang was applied to $translate
- Probably now an issue due to the landing page changes, we show the select lang directive quicker than before