### PR TITLE
Fix terminate instance UI

### DIFF
--- a/components/cloud-foundry/frontend/src/view/applications/application/application.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/application/application.module.js
@@ -149,6 +149,8 @@
       }
     ];
     vm.scheduledUpdate = undefined;
+    // Used in summary.module.js
+    vm.update = update;
     vm.autoUpdate = {
       update: update,
       interval: UPDATE_INTERVAL,

--- a/components/cloud-foundry/frontend/src/view/applications/application/summary/summary.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/application/summary/summary.module.js
@@ -157,7 +157,7 @@
               return vm.model.terminateRunningAppInstanceAtGivenIndex(vm.cnsiGuid, vm.id, instanceIndex)
                 .then(function () {
                   appNotificationsService.notify('success',
-                    $translate.instant('app.app-info.terminate-instance.terminate.success', { index: instanceIndex }));
+                    $translate.instant('app.app-info.terminate-instance.success', { index: instanceIndex }));
                   update();
                 });
             }


### PR DESCRIPTION
Couple of issues in the UI following successful termination of an app instance
- Untranslated string shown in success notification
- Modal shows failure after successfully terminating (exception during client refresh)