### PR TITLE
Persist app wall selection of cf/org/space in local storage

### DIFF
--- a/components/app-core/frontend/src/view/util/local-storage.service.js
+++ b/components/app-core/frontend/src/view/util/local-storage.service.js
@@ -68,7 +68,7 @@
       /**
        * @function getItem
        * @memberof app.view.appLocalStorage
-       * @description Get the item in the local storage for the given key. Optioanlly return the default value if not found.
+       * @description Get the item in the local storage for the given key. Optionally return the default value if not found.
        * @param {string} key - key of value fo retrieve
        * @param {string=} defaultValue - default value to be returned if no value is found
        * @returns {string} value from local storage for the given key

--- a/components/cloud-foundry/frontend/src/model/application/application.model.js
+++ b/components/cloud-foundry/frontend/src/model/application/application.model.js
@@ -17,9 +17,10 @@
     })
     .run(registerApplicationModel);
 
-  function registerApplicationModel(appConfig, modelManager, apiManager, cfAppStateService, $q, modelUtils) {
+  function registerApplicationModel(appConfig, modelManager, apiManager, cfAppStateService, $q, modelUtils,
+                                    appLocalStorage) {
     modelManager.register('cloud-foundry.model.application', new Application(appConfig, apiManager, modelManager,
-      cfAppStateService, $q, modelUtils));
+      cfAppStateService, $q, modelUtils, appLocalStorage));
   }
 
   /**
@@ -37,7 +38,7 @@
    * @property {number} pageSize - page size for pagination.
    * @class
    */
-  function Application(config, apiManager, modelManager, cfAppStateService, $q, modelUtils) {
+  function Application(config, apiManager, modelManager, cfAppStateService, $q, modelUtils, appLocalStorage) {
     var applicationApi = apiManager.retrieve('cloud-foundry.api.Apps');
     var loadingLimit = config.loadingLimit;
 
@@ -50,7 +51,7 @@
         appStateMap: {}
       },
       pageSize: config.pagination.pageSize,
-      filterParams: {
+      filterParams: angular.fromJson(appLocalStorage.getItem('cf.filterParams')) || {
         cnsiGuid: 'all',
         orgGuid: 'all',
         spaceGuid: 'all'

--- a/components/cloud-foundry/frontend/src/model/application/application.model.js
+++ b/components/cloud-foundry/frontend/src/model/application/application.model.js
@@ -32,6 +32,7 @@
    * @param {object} cfAppStateService - the Application State service
    * @param {object} $q - the $q service for promise/deferred objects
    * @param {cloud-foundry.model.modelUtils} modelUtils - a service containing general cf model helpers
+   * @param {appLocalStorage} appLocalStorage - service provides access to the local storage facility of the web browser
    * @property {object} data - holding data.
    * @property {object} application - the currently focused application.
    * @property {string} appStateSwitchTo - the state of currently focused application is switching to.

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
@@ -33,7 +33,7 @@
    * deploy, etc)
    */
   function ApplicationsListController($scope, $translate, $state, $timeout, $q, $window, modelManager, appErrorService,
-                                      appUtilsService, cfOrganizationModel, cfAppWallActions) {
+                                      appUtilsService, cfOrganizationModel, cfAppWallActions, appLocalStorage) {
 
     var vm = this;
 
@@ -109,6 +109,12 @@
       appErrorService.clearAppError();
       // Ensure that remove the resize handler on the window
       angular.element($window).off('resize', onResize);
+    });
+
+    $scope.$watch(function () {
+      return vm.model.filterParams.cnsiGuid + vm.model.filterParams.orgGuid + vm.model.filterParams.spaceGuid;
+    }, function () {
+      appLocalStorage.setItem('cf.filterParams', angular.toJson(vm.model.filterParams));
     });
 
     function onResize() {

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
@@ -31,6 +31,7 @@
    * @param {object} cfOrganizationModel - the cfOrganizationModel service
    * @param {object} cfAppWallActions - service providing collection of actions that can be taken on the app wall (add,
    * deploy, etc)
+   * @param {appLocalStorage} appLocalStorage - service provides access to the local storage facility of the web browser
    */
   function ApplicationsListController($scope, $translate, $state, $timeout, $q, $window, modelManager, appErrorService,
                                       appUtilsService, cfOrganizationModel, cfAppWallActions, appLocalStorage) {

--- a/components/cloud-foundry/frontend/test/e2e/log-stream.spec.js
+++ b/components/cloud-foundry/frontend/test/e2e/log-stream.spec.js
@@ -27,11 +27,12 @@
         })
         .then(function () {
           helpers.setBrowserNormal();
-          // Rest the cookies so that we get the default grid view and no saved org/space
-          helpers.loadApp(true);
+          helpers.loadApp();
           return loginPage.loginAsAdmin();
         })
         .then(function () {
+          // Ensure that no org or space is selected when we come into the app wall
+          galleryWall.resetFilters();
           return galleryWall.setGridView();
         });
       // Ensure we don't continue until everything is set up

--- a/components/cloud-foundry/frontend/test/e2e/log-stream.spec.js
+++ b/components/cloud-foundry/frontend/test/e2e/log-stream.spec.js
@@ -27,7 +27,8 @@
         })
         .then(function () {
           helpers.setBrowserNormal();
-          helpers.loadApp();
+          // Rest the cookies so that we get the default grid view and no saved org/space
+          helpers.loadApp(true);
           return loginPage.loginAsAdmin();
         })
         .then(function () {

--- a/components/cloud-foundry/frontend/test/unit/view/applications/list/list.module.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/applications/list/list.module.spec.js
@@ -27,6 +27,7 @@
       var cfOrganizationModel = $injector.get('cfOrganizationModel');
       var cfAppWallActions = $injector.get('cfAppWallActions');
       var $window = $injector.get('$window');
+      var appLocalStorage = $injector.get('appLocalStorage');
 
       var userCnsiModel = modelManager.retrieve('app.model.serviceInstance.user');
       if (Object.keys(userCnsiModel.serviceInstances).length === 0) {
@@ -52,7 +53,7 @@
 
       var ApplicationsListController = $state.get('cf.applications.list').controller;
       $controller = new ApplicationsListController($scope, $translate, $state, $timeout, $q, $window, modelManager,
-        errorService, appUtilsService, cfOrganizationModel, cfAppWallActions);
+        errorService, appUtilsService, cfOrganizationModel, cfAppWallActions, appLocalStorage);
       expect($controller).toBeDefined();
 
       var listAllOrgs = mock.cloudFoundryAPI.Organizations.ListAllOrganizations('default');


### PR DESCRIPTION
Currently we lose the selection over page reload. This can be quite frustrating if you're working in a particular space.