### PR TITLE
Pre-sort service instances in cloud foundry space instances table

### DIFF
--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/services/space-services.html
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/services/space-services.html
@@ -1,5 +1,5 @@
 <div class="space-services-table">
-  <div ng-if="!spaceSrvsCtrl.serviceInstances || spaceSrvsCtrl.serviceInstances.length < 1"
+  <div ng-if="spaceSrvsCtrl.serviceInstances && spaceSrvsCtrl.serviceInstances.length < 1"
        class="panel panel-default cluster-empty-list">
     <div class="panel-body" translate>cf.space-info.tabs.services.none</div>
   </div>

--- a/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/services/space-services.module.js
+++ b/components/cloud-foundry/frontend/src/view/dashboard/cluster/organization/space/detail/services/space-services.module.js
@@ -60,11 +60,15 @@
 
     appUtilsService.chainStateResolve('endpoint.clusters.cluster.organization.space.detail.services', $state, init);
 
+    function setServiceInstances(serviceInstances) {
+      vm.serviceInstances = _.sortBy(serviceInstances, function (o) { return o.entity.name.toLowerCase(); });
+    }
+
     function init() {
       if (angular.isUndefined(spaceDetail().instances)) {
         return update();
       }
-      vm.serviceInstances = spaceDetail().instances;
+      setServiceInstances(spaceDetail().instances);
       return $q.resolve();
     }
 
@@ -72,7 +76,7 @@
       return spaceModel.listAllServiceInstancesForSpace(vm.clusterGuid, vm.spaceGuid, {
         return_user_provided_service_instances: true
       }).then(function () {
-        vm.serviceInstances = spaceDetail().instances;
+        setServiceInstances(spaceDetail().instances);
         if (serviceInstance) {
           updateActions([serviceInstance]);
           spaceModel.updateServiceInstanceCount(vm.clusterGuid, vm.spaceGuid, _.keys(spaceDetail().instances).length);

--- a/components/cloud-foundry/frontend/test/unit/view/dashboard/cluster/organization/space/space-services.module.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/dashboard/cluster/organization/space/space-services.module.spec.js
@@ -17,6 +17,7 @@
         guid: 'serviceGuid'
       },
       entity: {
+        name: 'serviceName'
       }
     };
     var space = {


### PR DESCRIPTION
- Pre sort cluster space service instance table to avoid visual blip of unsorted entries
- Only show the 'no instances' message when we have no instances (not before the instances have been fetched)