### PR TITLE
Rename cnap headers to cap

### DIFF
--- a/components/app-core/backend/auth.go
+++ b/components/app-core/backend/auth.go
@@ -40,7 +40,7 @@ const UAAAdminIdentifier = "stratos.admin"
 const CFAdminIdentifier = "cloud_controller.admin"
 
 // SessionExpiresOnHeader Custom header for communicating the session expiry time to clients
-const SessionExpiresOnHeader = "X-Cnap-Session-Expires-On"
+const SessionExpiresOnHeader = "X-Cap-Session-Expires-On"
 
 // EmptyCookieMatcher - Used to detect and remove empty Cookies sent by certain browsers
 var EmptyCookieMatcher *regexp.Regexp = regexp.MustCompile(portalSessionName + "=(?:;[ ]*|$)")

--- a/components/app-core/backend/passthrough.go
+++ b/components/app-core/backend/passthrough.go
@@ -160,8 +160,8 @@ func fwdCNSIStandardHeaders(cnsiRequest *CNSIRequest, req *http.Request) {
 		switch {
 		// Skip these
 		//  - "Referer" causes CF to fail with a 403
-		//  - "Connection", "X-Cnap-*" and "Cookie" are consumed by us
-		case k == "Connection", k == "Cookie", k == "Referer", strings.HasPrefix(strings.ToLower(k), "x-cnap-"):
+		//  - "Connection", "X-Cap-*" and "Cookie" are consumed by us
+		case k == "Connection", k == "Cookie", k == "Referer", strings.HasPrefix(strings.ToLower(k), "x-cap-"):
 
 		// Forwarding everything else
 		default:
@@ -172,8 +172,8 @@ func fwdCNSIStandardHeaders(cnsiRequest *CNSIRequest, req *http.Request) {
 
 func (p *portalProxy) proxy(c echo.Context) error {
 	log.Debug("proxy")
-	cnsiList := strings.Split(c.Request().Header().Get("x-cnap-cnsi-list"), ",")
-	shouldPassthrough := "true" == c.Request().Header().Get("x-cnap-passthrough")
+	cnsiList := strings.Split(c.Request().Header().Get("x-cap-cnsi-list"), ",")
+	shouldPassthrough := "true" == c.Request().Header().Get("x-cap-passthrough")
 
 	if err := p.validateCNSIList(cnsiList); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
@@ -218,7 +218,7 @@ func (p *portalProxy) proxy(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusBadRequest, buildErr.Error())
 		}
 		// Allow the host part of the API URL to be overridden
-		apiHost := c.Request().Header().Get("x-cnap-api-host")
+		apiHost := c.Request().Header().Get("x-cap-api-host")
 		// Don't allow any '.' chars in the api name
 		if apiHost != "" && !strings.ContainsAny(apiHost, ".") {
 			// Add trailing . for when we replace

--- a/components/app-core/frontend/src/model/account.model.js
+++ b/components/app-core/frontend/src/model/account.model.js
@@ -128,7 +128,7 @@
      * @private
      */
     function onLoggedIn(response) {
-      var sessionExpiresOnEpoch = response.headers()['x-cnap-session-expires-on'];
+      var sessionExpiresOnEpoch = response.headers()['x-cap-session-expires-on'];
 
       var loginData = response.data || {};
       var loginRes = loginData.user ? loginData.user : loginData;

--- a/components/cloud-foundry/frontend/src/model/application/application.model.js
+++ b/components/cloud-foundry/frontend/src/model/application/application.model.js
@@ -265,7 +265,7 @@
               'results-per-page': 1
             }, {
               headers: {
-                'x-cnap-cnsi-list': _getCurrentCnsis().join(',')
+                'x-cap-cnsi-list': _getCurrentCnsis().join(',')
               }
             }).then(function (response) {
               model.unfilteredApplicationCount = _.sum(_.map(response.data, 'total_results'));
@@ -359,7 +359,7 @@
       }, _buildFilter());
       var config = {
         headers: {
-          'x-cnap-cnsi-list': cnsis.join(',')
+          'x-cap-cnsi-list': cnsis.join(',')
         }
       };
       return applicationApi.ListAllApps(options, config).then(function (response) {

--- a/components/cloud-foundry/frontend/src/model/model-utils.service.js
+++ b/components/cloud-foundry/frontend/src/model/model-utils.service.js
@@ -33,10 +33,10 @@
      * @returns {object} the $http service http config
      */
     function makeHttpConfig(cnsiGuid) {
-      var headers = {'x-cnap-cnsi-list': cnsiGuid};
+      var headers = {'x-cap-cnsi-list': cnsiGuid};
       // Add passthrough header
       angular.extend(headers, {
-        'x-cnap-passthrough': 'true'
+        'x-cap-passthrough': 'true'
       });
       return {
         headers: headers

--- a/components/cloud-foundry/frontend/src/model/model.module.js
+++ b/components/cloud-foundry/frontend/src/model/model.module.js
@@ -10,7 +10,7 @@
 
   /**
    * @name interceptor
-   * @description A $http interceptor that adds `x-cnap-cnsi-list`
+   * @description A $http interceptor that adds `x-cap-cnsi-list`
    * header to each request if the CNSI guid is present in the
    * URL (route).
    * @param {object} $stateParams - the UI router $stateParams service
@@ -27,8 +27,8 @@
       }
 
       var cnsiGuid = $stateParams.cnsiGuid;
-      if (angular.isUndefined(config.headers['x-cnap-cnsi-list']) && angular.isDefined(cnsiGuid)) {
-        config.headers['x-cnap-cnsi-list'] = cnsiGuid;
+      if (angular.isUndefined(config.headers['x-cap-cnsi-list']) && angular.isDefined(cnsiGuid)) {
+        config.headers['x-cap-cnsi-list'] = cnsiGuid;
       }
       return config;
     }

--- a/components/cloud-foundry/frontend/src/services/cfServiceEndpoint.services.js
+++ b/components/cloud-foundry/frontend/src/services/cfServiceEndpoint.services.js
@@ -67,7 +67,7 @@
     function refreshToken(allServiceInstances) {
       var cfInfoApi = apiManager.retrieve('cloud-foundry.api.Info');
       var cfGuids = _.map(_.filter(allServiceInstances, {cnsi_type: service.cnsi_type}) || [], 'guid') || [];
-      var cfCfg = {headers: {'x-cnap-cnsi-list': cfGuids.join(',')}};
+      var cfCfg = {headers: {'x-cap-cnsi-list': cfGuids.join(',')}};
       if (cfGuids.length > 0) {
         return cfInfoApi.GetInfo({}, cfCfg).then(function (response) {
           return response.data || {};

--- a/components/cloud-foundry/frontend/test/e2e/app-wall/common.js
+++ b/components/cloud-foundry/frontend/test/e2e/app-wall/common.js
@@ -52,7 +52,7 @@
       },
       user: {
         guid: '63ddbbe1-a185-465d-ba10-63d5c01f1a99',
-        name: 'admin@cnap.local',
+        name: 'admin@cap.local',
         admin: true
       },
       endpoints: {

--- a/components/cloud-foundry/frontend/test/e2e/po/models/cf-model.po.js
+++ b/components/cloud-foundry/frontend/test/e2e/po/models/cf-model.po.js
@@ -20,8 +20,8 @@
 
   function createHeader(cnsiGuid) {
     return {
-      'x-cnap-cnsi-list': cnsiGuid,
-      'x-cnap-passthrough': 'true'
+      'x-cap-cnsi-list': cnsiGuid,
+      'x-cap-passthrough': 'true'
     };
   }
 

--- a/components/cloud-foundry/frontend/test/unit/model/model-utils.service.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/model/model-utils.service.spec.js
@@ -20,8 +20,8 @@
       var cnsiGuid = '12345';
       expect(modelUtils.makeHttpConfig(cnsiGuid)).toEqual({
         headers: {
-          'x-cnap-cnsi-list': cnsiGuid,
-          'x-cnap-passthrough': 'true'
+          'x-cap-cnsi-list': cnsiGuid,
+          'x-cap-passthrough': 'true'
         }
       });
     });

--- a/components/cloud-foundry/frontend/test/unit/view/dashboard/tiles/cluster-tile.directive.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/dashboard/tiles/cluster-tile.directive.spec.js
@@ -125,7 +125,7 @@
 
       it('Call succeeds', function () {
         spyOn(cfAPIUsers, 'ListAllUsers').and.callFake(function (params, httpConfig) {
-          expect(httpConfig.headers['x-cnap-cnsi-list']).toEqual(initialService.guid);
+          expect(httpConfig.headers['x-cap-cnsi-list']).toEqual(initialService.guid);
           return $q.when({ data: { total_results: 2 }});
         });
         _.set(consoleInfo, 'info.endpoints.cf.' + initialService.guid + '.user.admin', true);
@@ -142,7 +142,7 @@
 
       it('Call succeeds - empty list', function () {
         spyOn(cfAPIUsers, 'ListAllUsers').and.callFake(function (params, httpConfig) {
-          expect(httpConfig.headers['x-cnap-cnsi-list']).toEqual(initialService.guid);
+          expect(httpConfig.headers['x-cap-cnsi-list']).toEqual(initialService.guid);
           return $q.when({ data: { total_results: 0 }});
         });
         _.set(consoleInfo, 'info.endpoints.cf.' + initialService.guid + '.user.admin', true);
@@ -159,7 +159,7 @@
 
       it('Call fails', function () {
         spyOn(cfAPIUsers, 'ListAllUsers').and.callFake(function (params, httpConfig) {
-          expect(httpConfig.headers['x-cnap-cnsi-list']).toEqual(initialService.guid);
+          expect(httpConfig.headers['x-cap-cnsi-list']).toEqual(initialService.guid);
           return $q.reject();
         });
         _.set(consoleInfo, 'info.endpoints.cf.' + initialService.guid + '.user.admin', true);
@@ -226,7 +226,7 @@
 
       it('Call succeeds', function () {
         spyOn(cfAPIOrg, 'ListAllOrganizations').and.callFake(function (params, httpConfig) {
-          expect(httpConfig.headers['x-cnap-cnsi-list']).toEqual(initialService.guid);
+          expect(httpConfig.headers['x-cap-cnsi-list']).toEqual(initialService.guid);
           return $q.when({ data: { total_results: 2 }});
         });
         createCtrl();
@@ -242,7 +242,7 @@
 
       it('Call succeeds - empty list', function () {
         spyOn(cfAPIOrg, 'ListAllOrganizations').and.callFake(function (params, httpConfig) {
-          expect(httpConfig.headers['x-cnap-cnsi-list']).toEqual(initialService.guid);
+          expect(httpConfig.headers['x-cap-cnsi-list']).toEqual(initialService.guid);
           return $q.when({ data: { total_results: 0 }});
         });
         createCtrl();
@@ -258,7 +258,7 @@
 
       it('Call fails', function () {
         spyOn(cfAPIOrg, 'ListAllOrganizations').and.callFake(function (params, httpConfig) {
-          expect(httpConfig.headers['x-cnap-cnsi-list']).toEqual(initialService.guid);
+          expect(httpConfig.headers['x-cap-cnsi-list']).toEqual(initialService.guid);
           return $q.reject();
         });
         createCtrl();

--- a/components/user-info/backend/user_info.go
+++ b/components/user-info/backend/user_info.go
@@ -129,8 +129,8 @@ func fwdHeaders(uaaReq engine.Request, req *http.Request) {
 		switch {
 		// Skip these
 		//  - "Referer" causes CF to fail with a 403
-		//  - "Connection", "X-Cnap-*" and "Cookie" are consumed by us
-		case k == "Connection", k == "Cookie", k == "Referer", strings.HasPrefix(strings.ToLower(k), "x-cnap-"):
+		//  - "Connection", "x-cap-*" and "Cookie" are consumed by us
+		case k == "Connection", k == "Cookie", k == "Referer", strings.HasPrefix(strings.ToLower(k), "x-cap-"):
 
 		// Forwarding everything else
 		default:


### PR DESCRIPTION
Renames the HTTP headers that use the term 'cnap' to use 'cap' instead.