### PR TITLE
Workaround for chrome tripple click bug

### DIFF
--- a/components/endpoints-dashboard/src/view/view.html
+++ b/components/endpoints-dashboard/src/view/view.html
@@ -53,7 +53,7 @@
           <th translate st-sort="name" st-skip-natural="true" translate>endpoints-dashboard.table.name</th>
           <th translate st-sort="connected" st-skip-natural="true" translate>endpoints-dashboard.table.connection</th>
           <th translate st-sort="type" st-sort-default="true" st-skip-natural="true" translate>endpoints-dashboard.table.type</th>
-          <th translate st-sort="url" st-skip-natural="true" translate>endpoints-dashboard.table.address</th>
+          <th translate st-sort="url" st-skip-natural="true" translate colspan="2">endpoints-dashboard.table.address</th>
           <th></th>
         </tr>
         </thead>
@@ -90,6 +90,8 @@
 
           <td translate>{{ endpoint.type }}</td>
           <td>{{ endpoint.url }}</td>
+          <!-- Add an empty to row to work around chrome issue when copying after triple click on endpoint url -->
+          <td></td>
           <td>
             <actions-menu actions="endpoint.actions"
                           action-target="endpoint.actionsTarget"

--- a/components/endpoints-dashboard/test/e2e/po/endpoints-dashboard.spec.js
+++ b/components/endpoints-dashboard/test/e2e/po/endpoints-dashboard.spec.js
@@ -538,7 +538,7 @@
             endpointsPage.credentialsFormEndpointConnect().then(function () {
               helpers.checkAndCloseToast(/Successfully connected to '(?:cf)'/);
               var endpointsTable = endpointsPage.getEndpointTable();
-              expect(helpers.getTableCellAt(endpointsTable, cfRowIndex, 4).getText()).toBe('DISCONNECT');
+              expect(helpers.getTableCellAt(endpointsTable, cfRowIndex, 5).getText()).toBe('DISCONNECT');
               expect(endpointsPage.endpointIsConnected(cfRowIndex)).toBeTruthy();
             });
           });
@@ -574,7 +574,7 @@
               .then(function () {
                 helpers.checkAndCloseToast(/Successfully disconnected endpoint '(?:cf)'/);
                 var endpointsTable = endpointsPage.getEndpointTable();
-                expect(helpers.getTableCellAt(endpointsTable, cfRowIndex, 4).getText()).toBe('CONNECT');
+                expect(helpers.getTableCellAt(endpointsTable, cfRowIndex, 5).getText()).toBe('CONNECT');
               });
           });
 

--- a/components/endpoints-dashboard/test/e2e/po/endpoints/endpoints-dashboard.po.js
+++ b/components/endpoints-dashboard/test/e2e/po/endpoints/endpoints-dashboard.po.js
@@ -205,7 +205,7 @@
   }
 
   function endpointActionMenu(row) {
-    return helpers.getTableCellAt(getEndpointTable(), row, 4).element(by.css('actions-menu'));
+    return helpers.getTableCellAt(getEndpointTable(), row, 5).element(by.css('actions-menu'));
   }
 
   function endpointUrl(row) {


### PR DESCRIPTION
- Tripple click on endpoint dashboard endpoint url lead to selection of icon as well

"https://api.10.84.93.96.nip.io:8443

more_horiz"

- Not applicable to last row (works fine)
- No amount of user-select:none, < p >, etc fixed this
- Behaviour only visible on chrome
- Work around of additional column between url and actions
- Result..

"https://api.10.84.93.96.nip.io:8443 "