### PR TITLE
Fix incorrect caching and reset behaviour of app wall filters

### DIFF
--- a/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
@@ -276,6 +276,9 @@
             }
           });
       } else {
+        // Cluster is set to all, so should org
+        vm.model.filterParams.orgGuid = 'all';
+        vm.filter.orgGuid = 'all';
         return $q.resolve();
       }
     }
@@ -313,6 +316,9 @@
             }
           });
       } else {
+        // Cluster & org are set to all, so should space
+        vm.model.filterParams.spaceGuid = 'all';
+        vm.filter.spaceGuid = 'all';
         return $q.resolve();
       }
     }
@@ -407,8 +413,8 @@
     }
 
     /**
-     * @function getClusterOrganizations
-     * @description Get organizations for selected cluster
+     * @function setCluster
+     * @description
      * @returns {void}
      * @public
      */

--- a/components/cloud-foundry/frontend/test/unit/view/applications/list/list.module.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/applications/list/list.module.spec.js
@@ -439,7 +439,7 @@
           appModel.filterParams.spaceGuid = 'junk3';
 
           setUp();
-          $httpBackend.flush();
+          $scope.$digest();
 
           check(allFilterValue, 3, allFilterValue, 1, allFilterValue, 1);
         });
@@ -465,6 +465,16 @@
           check(cnsiGuid, 3, allFilterValue, 3, allFilterValue, 1);
         });
 
+        it('avoids bad value - org only', function () {
+          var appModel = modelManager.retrieve('cloud-foundry.model.application');
+          appModel.filterParams.orgGuid = 'junk2';
+
+          setUp();
+          $scope.$digest();
+
+          check(allFilterValue, 3, allFilterValue, 1, allFilterValue, 1);
+        });
+
         it('avoids bad value - space', function () {
           var appModel = modelManager.retrieve('cloud-foundry.model.application');
           appModel.filterParams.cnsiGuid = cnsiGuid;
@@ -475,6 +485,16 @@
           $httpBackend.flush();
 
           check(cnsiGuid, 3, orgGuid, 3, allFilterValue, 3);
+        });
+
+        it('avoids bad value - space only', function () {
+          var appModel = modelManager.retrieve('cloud-foundry.model.application');
+          appModel.filterParams.spaceGuid = 'junk3';
+
+          setUp();
+          $scope.$digest();
+
+          check(allFilterValue, 3, allFilterValue, 1, allFilterValue, 1);
         });
 
       });


### PR DESCRIPTION
- Ensure that when we reset dodgy cluster/org values we also reset org/space
- Previously we were showing filter by 'all' for org/space but still applying filter containing valid org/space guid
- Reset fixed by not entering dodgy state