### PR TITLE
Fixes for e2e tests timing out

### DIFF
--- a/build/e2e.gulp.js
+++ b/build/e2e.gulp.js
@@ -18,6 +18,7 @@
   var path = require('path');
   var runSequence = require('run-sequence');
   var ngAnnotate = require('gulp-ng-annotate');
+  var e2eConfigFile = './build/coverage.conf.js';
 
   var components;
   gulp.task('prepare:e2e', function () {
@@ -42,6 +43,13 @@
     combine(opts, cb);
   });
 
+  gulp.task('e2e:nocov', function () {
+    e2eConfigFile = './build/protractor.conf.js';
+    runSequence(
+      'e2e:tests'
+    );
+  });
+
   gulp.task('e2e:tests', function (cb) {
     // Use the protractor in our node_modules folder
     var cmd = './node_modules/protractor/bin/protractor';
@@ -50,7 +58,7 @@
     options.env.NODE_ENV = 'development';
     options.env.env = 'development';
 
-    var args = ['./build/coverage.conf.js'];
+    var args = [e2eConfigFile];
     if (process.env.STRATOS_E2E_SUITE) {
       args.push('--suite');
       args.push(process.env.STRATOS_E2E_SUITE);

--- a/build/protractor.conf.js
+++ b/build/protractor.conf.js
@@ -56,8 +56,8 @@
 
     params: {
       protocol: 'https://',
-      host: 'localhost',
-      port: '3100',
+      host: secrets.console.host || 'localhost',
+      port: secrets.console.port || '3100',
       credentials: {
         admin: secrets.console.admin,
         user: secrets.console.user
@@ -165,6 +165,7 @@
     },
 
     jasmineNodeOpts: {
+      defaultTimeoutInterval: 45000,
       // disable default jasmine report (using jasmine-spec-reporter)
       print: function () {
       }

--- a/components/cloud-foundry/frontend/test/e2e/application.spec.js
+++ b/components/cloud-foundry/frontend/test/e2e/application.spec.js
@@ -68,7 +68,7 @@
       });
     });
 
-    describe('Summary Tab', function () {
+    fdescribe('Summary Tab', function () {
       beforeAll(function () {
         // Summary tab
         application.showSummary();
@@ -205,13 +205,15 @@
               var appRouteAttachedTo = rows[index][1];
               expect(appRouteAttachedTo).toBeDefined();
               expect(appRouteAttachedTo.length).toBeGreaterThan(0);
-              expect(appRouteAttachedTo, testAppName);
+              expect(appRouteAttachedTo).toContain(testAppName);
 
               var columnMenu = actionMenu.wrap(routes.getItem(index, 2));
               columnMenu.waitForElement();
-
+              helpers.scrollIntoView(columnMenu);
+              
               // Unmap Route
               columnMenu.click();
+
               columnMenu.clickItem(1);
               confirmModal.waitForModal();
               expect(confirmModal.getTitle()).toBe('Unmap Route from Application');

--- a/components/cloud-foundry/frontend/test/e2e/application.spec.js
+++ b/components/cloud-foundry/frontend/test/e2e/application.spec.js
@@ -210,7 +210,7 @@
               var columnMenu = actionMenu.wrap(routes.getItem(index, 2));
               columnMenu.waitForElement();
               helpers.scrollIntoView(columnMenu);
-              
+
               // Unmap Route
               columnMenu.click();
 

--- a/components/cloud-foundry/frontend/test/e2e/application.spec.js
+++ b/components/cloud-foundry/frontend/test/e2e/application.spec.js
@@ -68,7 +68,7 @@
       });
     });
 
-    fdescribe('Summary Tab', function () {
+    describe('Summary Tab', function () {
       beforeAll(function () {
         // Summary tab
         application.showSummary();


### PR DESCRIPTION
- Increase time out for tests to 1 minute (default 30s)
- Add a target to run e2e tests without coverage
- Allow console host and port to be configured - allows running tests against another deployment
- Fixed route test that failed if there were lots of routes in the e2e space