### PR TITLE
Pin MariaDB helm chart version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ deploy/ci/secrets.yml
 deploy/kubernetes/values.yaml
 deploy/cloud-foundry/db-migration/goose
 outputs/
-
+deploy/kubernetes/console/charts/
 deploy/stratos-ui-release/.dev_builds
 deploy/stratos-ui-release/blobs
 deploy/stratos-ui-release/dev_releases/

--- a/deploy/ci/tasks/release/create-chart.yml
+++ b/deploy/ci/tasks/release/create-chart.yml
@@ -31,6 +31,7 @@ run:
       cp -f ${ROOT_DIR}/helm-chart-Chart/Chart.yaml* console/Chart.yaml
 
       # Generate Helm package
+      helm dep build console
       helm package console
       cp console*.tgz ${ROOT_DIR}/helm-chart/console-helm-chart-${SHORT_GIT_TAG}.tgz
       cd ${ROOT_DIR}/helm-chart/

--- a/deploy/kubernetes/console/requirements.lock
+++ b/deploy/kubernetes/console/requirements.lock
@@ -1,0 +1,11 @@
+dependencies:
+- alias: ""
+  condition: ""
+  enabled: false
+  import-values: null
+  name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  tags: null
+  version: 1.0.1
+digest: sha256:5f5af6467b33fc5c07ddf7197b6625d3489fc5bb2e21bb362dc27867c63c85bf
+generated: 2017-09-15T15:21:55.915717316+01:00

--- a/deploy/kubernetes/console/requirements.yaml
+++ b/deploy/kubernetes/console/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: mariadb
+  version: "1.0.1"
+  repository: https://kubernetes-charts.storage.googleapis.com/


### PR DESCRIPTION
1. Adds `requirements.yaml` to console helm chart to pin version of the mariadb dependency.
2. Adds a missing `helm build dep` step to the build-release pipeline to fetch dependencies before packaging final helm chart.