### PR TITLE
Fix filter by text/endpoint bug

### DIFF
--- a/components/cloud-foundry/frontend/src/model/application/application.model.js
+++ b/components/cloud-foundry/frontend/src/model/application/application.model.js
@@ -273,17 +273,15 @@
           }
         })
         .then(function () {
-          var didFilter = false;
+          // Always start from a fresh filtered state
+          resetFilter();
+
           if (model.filterParams.cnsiGuid !== 'all') {
             filterByCluster(model.filterParams.cnsiGuid);
-            didFilter = true;
           }
+
           if (model.filterParams.text) {
             filterByText(model.filterParams.text);
-            didFilter = true;
-          }
-          if (!didFilter) {
-            resetFilter();
           }
         })
         .catch(_.bind(_onListAllAppsFailure, this));
@@ -487,14 +485,14 @@
      * @public
      */
     function filterByCluster(clusterId) {
-      model.filteredApplications = _.filter(model.cachedApplications, ['clusterId', clusterId]);
+      model.filteredApplications = _.filter(model.filteredApplications, ['clusterId', clusterId]);
       _sortFilteredApplications();
       model.hasApps = model.filteredApplications.length > 0;
     }
 
     function filterByText(text) {
       text = text.toLowerCase();
-      model.filteredApplications = _.filter(model.cachedApplications, function (app) {
+      model.filteredApplications = _.filter(model.filteredApplications, function (app) {
         if (app.entity.name.toLowerCase().indexOf(text) > -1) {
           return app;
         }

--- a/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/list/list.module.js
@@ -433,18 +433,7 @@
           // changed the org and space filter
           needToReload = needToReload || !_.isMatch(vm.filter, {orgGuid: 'all', spaceGuid: 'all'});
 
-          if (needToReload) {
-            _reload();
-          } else {
-            if (vm.filter.cnsiGuid === 'all') {
-              vm.model.resetFilter();
-            } else {
-              vm.model.filterByCluster(vm.filter.cnsiGuid);
-            }
-            vm.paginationProperties.pageNumber = 1;
-            vm.paginationProperties.total = _.ceil(vm.model.filteredApplications.length / vm.model.pageSize);
-            _loadPage(1);
-          }
+          _reload(false, !needToReload);
         });
     }
 


### PR DESCRIPTION
To reproduce bug...
- Add provo1 + provo2
- filter by 'node-env'
- two apps are shown
- filter endpoint to provo 1
- filter applies endpoint but not text to result set