### PR TITLE
Use MariaDB in docker-compose

### DIFF
--- a/deploy/docker-compose.development.yml
+++ b/deploy/docker-compose.development.yml
@@ -9,20 +9,17 @@ services:
       file: common.yml
       service: ui
 
-
-  postgres:
+  mariadb:
     extends:
       file: common.yml
-      service: postgres
-
+      service: mariadb
 
   goose:
     extends:
       file: common.yml
       service: goose
     links:
-      - postgres:postgres
-
+      - mariadb:mariadb
 
   proxy:
     extends:


### PR DESCRIPTION
Test docker-compose and no-ui docker-compose already use mariaDB. However, docker-compose.development.yml wasn't updated to use mariadb.