### PR TITLE
Update requirements lock file for Helm 2.6

### DIFF
--- a/deploy/ci/scripts/Dockerfile.stratos-helm
+++ b/deploy/ci/scripts/Dockerfile.stratos-helm
@@ -1,0 +1,6 @@
+FROM alpine:3.6
+RUN apk add --update --no-cache ca-certificates git curl
+ENV VERSION v2.6.1
+ENV FILENAME helm-${VERSION}-linux-amd64.tar.gz
+RUN curl -L http://storage.googleapis.com/kubernetes-helm/${FILENAME} | tar xzv && \
+    mv /linux-amd64/helm /bin/helm

--- a/deploy/ci/tasks/release/create-chart.yml
+++ b/deploy/ci/tasks/release/create-chart.yml
@@ -9,7 +9,8 @@ outputs:
 image_resource:
   type: docker-image
   source:
-   repository:  ci-registry.ngrok.io:80/linkyard/helm
+  # Generated using Dockerfile.stratos-helm
+   repository:  ci-registry.ngrok.io:80/stratos-helm
    tag: "latest"
    insecure_registries: [ "ci-registry.ngrok.io:80" ]
 

--- a/deploy/kubernetes/console/requirements.lock
+++ b/deploy/kubernetes/console/requirements.lock
@@ -1,11 +1,6 @@
 dependencies:
-- alias: ""
-  condition: ""
-  enabled: false
-  import-values: null
-  name: mariadb
+- name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  tags: null
   version: 1.0.1
-digest: sha256:5f5af6467b33fc5c07ddf7197b6625d3489fc5bb2e21bb362dc27867c63c85bf
-generated: 2017-09-15T15:21:55.915717316+01:00
+digest: sha256:ccfff7c376d31903c1df1cdbedde7f46007ea3c43ebffc93f7f922fa0c0ca150
+generated: 2017-10-03T09:42:27.589253916+01:00

--- a/deploy/kubernetes/console/requirements.yaml
+++ b/deploy/kubernetes/console/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: "1.0.1"
+  version: 1.0.1
   repository: https://kubernetes-charts.storage.googleapis.com/


### PR DESCRIPTION
1. Helm 2.5 was used to generate the currently checked in lock file. This contained a bug that added extra fields to the lock file, newer versions of Helm fail to build chart.
2. Changes the docker image used when building the release pipelines. 
