### PR TITLE
Updates to the Helm chart

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -76,6 +76,11 @@ Open a terminal and cd to the `deploy/kubernetes` directory:
 $ cd deploy/kubernetes
 ```
 
+Fetch dependant helm charts
+```
+$ helm dep build
+```
+
 Run helm install:
 
 ```

--- a/deploy/kubernetes/console/templates/service.yaml
+++ b/deploy/kubernetes/console/templates/service.yaml
@@ -17,7 +17,11 @@ spec:
   selector:
     app: "{{ .Release.Name }}"
     component: console
+{{- if .Values.useLb }}
+  type: LoadBalancer
+{{- else }}
   type: NodePort
+{{- end }}
 {{- if .Values.console.externalIP }}
   externalIPs:
   -  {{ .Values.console.externalIP }}

--- a/deploy/kubernetes/console/templates/service.yaml
+++ b/deploy/kubernetes/console/templates/service.yaml
@@ -13,25 +13,12 @@ spec:
   - name: https
     port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: {{ .Values.console.port }}
   selector:
     app: "{{ .Release.Name }}"
     component: console
   type: NodePort
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: console-postgres
-  name: "{{ .Release.Name }}-postgres-int"
-spec:
-  ports:
-  - name: postgres
-    port: 5432
-    protocol: TCP
-    targetPort: 5432
-  selector:
-    app: "{{ .Release.Name }}"
-    component: postgres
-  type: ClusterIP
+{{- if .Values.console.externalIP }}
+  externalIPs:
+  -  {{ .Values.console.externalIP }}
+{{- end }}

--- a/deploy/kubernetes/console/values.yaml
+++ b/deploy/kubernetes/console/values.yaml
@@ -13,6 +13,7 @@ dbProvider: mysql
 #noProxy: localhost
 #ftpProxy: proxy.corp.net
 #socksProxy: sock-proxy.corp.net
+useLb: false
 console:
   port: 443
 # externalIP: 127.0.0.1

--- a/deploy/kubernetes/console/values.yaml
+++ b/deploy/kubernetes/console/values.yaml
@@ -13,6 +13,9 @@ dbProvider: mysql
 #noProxy: localhost
 #ftpProxy: proxy.corp.net
 #socksProxy: sock-proxy.corp.net
+console:
+  port: 443
+# externalIP: 127.0.0.1
 noShared: false
 images:
   console: stratos-console
@@ -43,7 +46,7 @@ mariadb:
   mariadbPassword: changeme
   mariadbDatabase: console
   persistence:
-    accessMode: ReadWriteMany
+    accessMode: ReadWriteOnce
     size: 1Gi
 #    storageClass: default
   metrics:


### PR DESCRIPTION
1. Remove legacy postgres service definition
2. Add parameter to specify an external IP if one is available in the cluster
3. Add parameter to specify is Console external endpoint should use a load balancer.
3. Change MariaDB volume access mode to `ReadWriteOnce`. This allows read/write access to the volume to one container only. The default access mode `ReadWriteMany` allows several containers to mount the volume for load balancing and fault tolerance.
4. Update README.md to document additional step required when building from the repository