### PR TITLE
Fix MariaDB permission issue in Kubernetes

### DIFF
--- a/deploy/kubernetes/console/values.yaml
+++ b/deploy/kubernetes/console/values.yaml
@@ -41,6 +41,7 @@ images:
 mariadb:
   # Only required for creating the databases
   mariadbRootPassword: changeme
+  image: splatform/stratos-mariadb:10.1.28-r2
   adminUser: root
   # Credentials for user
   mariadbUser: console


### PR DESCRIPTION

This changes the helm chart to use custom image built from the Dockerfile at https://github.com/irfanhabib/bitnami-docker-mariadb/tree/master/10.1.

MariaDB helm chart runs an init task to change permissions of the attached volume. See (https://github.com/irfanhabib/bitnami-docker-mariadb/blob/master/kubernetes.yml). However to maintain CAASP 1 (Kubernetes 1.5) support we are using an older version of the chart that does not do this.

The start script in this task changes the permissions so that the mysql server running as user `mysql` is able to read/write to the volume.