### PR TITLE
Make sure the expiry date time is relative to the time as the client sees it

### DIFF
--- a/components/app-core/backend/auth.go
+++ b/components/app-core/backend/auth.go
@@ -103,16 +103,6 @@ func (p *portalProxy) loginToUAA(c echo.Context) error {
 		return err
 	}
 
-	// Explicitly tell the client when this session will expire. This is needed because browsers actively hide
-	// the Set-Cookie header and session cookie expires_on from client side javascript
-	expOn, err := p.GetSessionValue(c, "expires_on")
-	if err != nil {
-		msg := "Could not get session expiry"
-		log.Error(msg+" - ", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, msg)
-	}
-	c.Response().Header().Set(SessionExpiresOnHeader, strconv.FormatInt(expOn.(time.Time).Unix(), 10))
-
 	_, err = p.saveUAAToken(*u, uaaRes.AccessToken, uaaRes.RefreshToken)
 	if err != nil {
 		return err

--- a/components/app-core/backend/auth.go
+++ b/components/app-core/backend/auth.go
@@ -98,7 +98,7 @@ func (p *portalProxy) loginToUAA(c echo.Context) error {
 		return err
 	}
 
-	err := p.handleSessionExpiryHeader(c)
+	err = p.handleSessionExpiryHeader(c)
 	if err != nil {
 		return err
 	}
@@ -532,7 +532,7 @@ func (p *portalProxy) verifySession(c echo.Context) error {
 		}
 	}
 
-	err := p.handleSessionExpiryHeader(c)
+	err = p.handleSessionExpiryHeader(c)
 	if err != nil {
 		return err
 	}
@@ -562,18 +562,20 @@ func (p *portalProxy) handleSessionExpiryHeader(c echo.Context) error {
 	}
 	c.Response().Header().Set(SessionExpiresOnHeader, strconv.FormatInt(expOn.(time.Time).Unix(), 10))
 
-	expiry := expOn.(time.Time).Unix()
-	expiryDuration := time.Now().Sub(expiry)
+	expiry := expOn.(time.Time)
+	expiryDuration := expiry.Sub(time.Now())
 
 	// Subtract time now to get the duration add this to the time provided by the client
 	if c.Request().Header().Contains(ClientRequestDateHeader) {
 		clientDate := c.Request().Header().Get(ClientRequestDateHeader)
-		clientDateInt, err := strconf.ParseInt(clientDate, 10, 64)
+		clientDateInt, err := strconv.ParseInt(clientDate, 10, 64)
 		if err == nil {
-			clientDateInt += expiryDuration
+			clientDateInt += int64(expiryDuration.Seconds())
 			c.Response().Header().Set(SessionExpiresOnHeader, strconv.FormatInt(clientDateInt, 10))
 		}
 	}
+
+	return nil
 }
 
 func (p *portalProxy) getUAAUser(userGUID string) (*interfaces.ConnectedUser, error) {

--- a/components/app-core/frontend/src/api/account.api.js
+++ b/components/app-core/frontend/src/api/account.api.js
@@ -46,7 +46,8 @@
     function login(username, password) {
       var config = {
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded'
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'x-cap-request-date': moment().unix()
         }
       };
       var data = $httpParamSerializer({ username: username, password: password });
@@ -72,7 +73,12 @@
      * @public
      */
     function verifySession() {
-      return $http.get('/pp/v1/auth/session/verify');
+      var config = {
+        headers: {
+          'x-cap-request-date': moment().unix()
+        }
+      };
+      return $http.get('/pp/v1/auth/session/verify', config);
     }
 
     function userInfo() {


### PR DESCRIPTION
The client now sends the time as it sees it in a custom header.

The backend will return the session expiry as a timestamp based on the client's timestamp.

The original error occurs when someone changes the time by modifying the time itself rather than changing the timezone - e.g. if you were in Prague, you leave the timezone as London, but manually add 1 hour to the time.