### PR TITLE
Update .cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -16,3 +16,4 @@ deploy/docker-compose/
 deploy/stratos-ui-release/
 deploy/kubernetes/
 docs/
+build/dev_config.json


### PR DESCRIPTION
If you have a build/dev_config.json that specifies a local dev build, this will blow the disk quota.

This PR adds this file to the ignore list since it is not needed.