### PR TITLE
Build the Database migrator tool as part of the backend build

### DIFF
--- a/build/bk-build.js
+++ b/build/bk-build.js
@@ -222,7 +222,7 @@
 
     // copy db migrator artefact
     var dbMigratorPath = path.join(prepareBuild.getDbMigratorSourcePath(), conf.dbMigratorName);
-    var outputDbMigratorPath = path.join(outputPath, conf.dbMigatorName);
+    var outputDbMigratorPath = path.join(outputPath, conf.dbMigratorName);
 
     promise
       .then(function () {

--- a/build/bk-build.js
+++ b/build/bk-build.js
@@ -63,9 +63,9 @@
 
     // DB Migrator dependencies
     promise = promise
-    .then(function () {
-      return buildUtils.runGlideInstall(prepareBuild.getDbMigratorSourcePath());
-    });
+      .then(function () {
+        return buildUtils.runGlideInstall(prepareBuild.getDbMigratorSourcePath());
+      });
 
     var fullCorePath = path.join(prepareBuild.getSourcePath(), 'app-core', 'backend');
 

--- a/build/bk-build.js
+++ b/build/bk-build.js
@@ -41,7 +41,7 @@
     }
   });
 
-  gulp.task('init-build', ['copy-portal-proxy', 'create-outputs'], function () {
+  gulp.task('init-build', ['copy-portal-proxy', 'copy-dbmigrator', 'create-outputs'], function () {
     buildUtils.init();
   });
 
@@ -60,6 +60,13 @@
         });
 
     });
+
+    // DB Migrator dependencies
+    promise = promise
+    .then(function () {
+      return buildUtils.runGlideInstall(prepareBuild.getDbMigratorSourcePath());
+    });
+
     var fullCorePath = path.join(prepareBuild.getSourcePath(), 'app-core', 'backend');
 
     promise
@@ -84,6 +91,7 @@
       return done();
     }
 
+    // Plugins
     var promise = Q.resolve();
     var promises = [];
     _.each(enabledPlugins, function (pluginInfo) {
@@ -111,6 +119,25 @@
         });
       promises.push(promise);
     });
+
+    // DB Migrator
+    promise
+      .then(function () {
+        var goSrc = path.join(prepareBuild.getGOPATH(), 'src');
+        var dbMigratorVendorPath = path.join(prepareBuild.getDbMigratorSourcePath(), 'vendor');
+        var dbMigratorCheckedInVendorPath = path.join(prepareBuild.getDbMigratorSourcePath(), '__vendor');
+        mergeDirs.default(dbMigratorVendorPath, goSrc);
+        if (fs.existsSync(dbMigratorCheckedInVendorPath)) {
+          mergeDirs.default(dbMigratorCheckedInVendorPath, goSrc);
+        }
+        fs.removeSync(dbMigratorVendorPath);
+        return Q.resolve();
+      })
+      .catch(function (err) {
+        done(err);
+      });
+
+    // App Core
     Q.all(promises)
       .then(function () {
         var goSrc = path.join(prepareBuild.getGOPATH(), 'src');
@@ -127,7 +154,6 @@
         done();
       })
       .catch(function (err) {
-
         done(err);
       });
   });
@@ -157,6 +183,18 @@
       });
   });
 
+  gulp.task('build-dbmigrator', [], function (done) {
+    buildUtils.init();
+    var dbMigratorPath = prepareBuild.getDbMigratorSourcePath();
+    buildUtils.build(dbMigratorPath, conf.dbMigratorName)
+      .then(function () {
+        done();
+      })
+      .catch(function (err) {
+        done(err);
+      });
+  });
+
   gulp.task('run-tests', ['build-all'], function (done) {
 
     var corePath = conf.getCorePath(prepareBuild.getSourcePath());
@@ -170,7 +208,7 @@
 
   });
 
-  gulp.task('copy-artefacts', ['build-all'], function (done) {
+  gulp.task('copy-artefacts', ['build-all', 'build-dbmigrator'], function (done) {
     var outputPath = conf.outputPath + path.sep;
     var promise = fsEnsureDirQ(outputPath);
     _.each(enabledPlugins, function (pluginInfo) {
@@ -181,6 +219,15 @@
           return fsMoveQ(compiledPluginPath, outputsPluginPath);
         });
     });
+
+    // copy db migrator artefact
+    var dbMigratorPath = path.join(prepareBuild.getDbMigratorSourcePath(), conf.dbMigratorName);
+    var outputDbMigratorPath = path.join(outputPath, conf.dbMigatorName);
+
+    promise
+      .then(function () {
+        return fsMoveQ(dbMigratorPath, outputDbMigratorPath);
+      });
 
     // copy core artefact
     var corePath = path.join(conf.getCorePath(prepareBuild.getSourcePath(), conf.coreName));
@@ -200,7 +247,6 @@
   });
 
   gulp.task('write-plugins-yaml', ['copy-artefacts'], function () {
-
     var plugins = _.values(enabledPlugins);
     fsWriteJsonQ(path.join(conf.outputPath, 'plugins.json'), plugins)
       .then(function () {

--- a/build/bk-conf.js
+++ b/build/bk-conf.js
@@ -4,6 +4,7 @@
   var path = require('path');
   module.exports = {
     goPath: path.join('src', 'github.com', 'SUSE', 'stratos-ui'),
+    goPathDbMigrator: path.join('src', 'github.com', 'SUSE', 'stratos-dbmigrator'),
     getVendorPath: function (srcPath) {
       return path.join(srcPath, 'vendor', 'github.com', 'SUSE', 'stratos-ui');
     },
@@ -11,6 +12,7 @@
       return path.join(srcPath, 'app-core', 'backend', executable ? executable : '');
     },
     coreName: 'portal-proxy',
+    dbMigratorName: 'stratos-dbmigrator',
     outputPath: path.join(__dirname, '..', 'outputs'),
     srcPath: path.join(__dirname, 'components')
   };

--- a/build/bk-prepare-build.js
+++ b/build/bk-prepare-build.js
@@ -11,7 +11,7 @@
   var conf = require('./bk-conf');
   var glob = require('glob');
 
-  var tempPath, tempSrcPath, buildTest;
+  var tempPath, tempSrcPath, tempDbMigratorSrcPath, buildTest;
   var fsEnsureDirQ = Q.denodeify(fs.ensureDir);
   var fsRemoveQ = Q.denodeify(fs.remove);
   var fsCopyQ = Q.denodeify(fs.copy);
@@ -30,6 +30,10 @@
 
   module.exports.getSourcePath = function () {
     return tempSrcPath;
+  };
+
+  module.exports.getDbMigratorSourcePath = function () {
+    return tempDbMigratorSrcPath;
   };
 
   gulp.task('clean-backend', function (done) {
@@ -60,6 +64,7 @@
     if (process.env.STRATOS_TEMP) {
       tempPath = process.env.STRATOS_TEMP;
       tempSrcPath = tempPath + path.sep + conf.goPath + path.sep + 'components';
+      tempDbMigratorSrcPath = tempPath + path.sep + conf.goPathDbMigrator;
       return done();
     } else {
       mktemp.createDir('/tmp/stratos-ui-XXXX.build',
@@ -69,10 +74,10 @@
           }
           tempPath = path_;
           tempSrcPath = path.join(tempPath, conf.goPath, 'components');
+          tempDbMigratorSrcPath = path.join(tempPath, conf.goPathDbMigrator);
           done();
         });
     }
-
   });
 
   gulp.task('delete-temp', [], function (done) {
@@ -124,4 +129,47 @@
         done(err);
       });
   });
+
+  // DB Migrator
+  gulp.task('copy-dbmigrator', ['create-temp'], function (done) {
+    fs.ensureDir(tempDbMigratorSrcPath, function (err) {
+      if (err) {
+        throw err;
+      }
+
+      fsCopyQ('./deploy/db/migrations', tempDbMigratorSrcPath)
+      .then(function () {
+        generateMigrationIndex(done);
+      })
+      .catch(function (err) {
+        done(err);
+      });
+    });
+  });
+
+  // Create go file that references all of the detected migration files
+  function generateMigrationIndex(done) {
+    fs.readdir(tempDbMigratorSrcPath, function (err, files) {
+      if (err || !files) {
+        return done(err);
+      }
+      var migrations = _.filter(files, function (item) {
+        return item.indexOf('20') === 0 && item.indexOf('.go') === item.length - 3;
+      });
+      migrations = _.map(migrations, function (item) {
+        var name = item.substr(0, item.length - 3);
+        var parts = name.split('_');
+        return parts[0];
+      });
+
+      var migrationsGoFileContent = 'package main\n\nimport (\n\t"database/sql"\n)\n\n';
+      _.each(migrations, function (name) {
+        migrationsGoFileContent += 'func (s *StratosMigrations) Up_' + name + '(txn *sql.Tx) {\n\tUp_' + name + '(txn)\n}\n';
+      });
+
+      var migrationsOutputFile = path.join(tempDbMigratorSrcPath, 'migrations.go');
+      fs.writeFile(migrationsOutputFile, migrationsGoFileContent, done);
+    });
+  }
+
 })();

--- a/build/bk-prepare-build.js
+++ b/build/bk-prepare-build.js
@@ -138,12 +138,12 @@
       }
 
       fsCopyQ('./deploy/db/migrations', tempDbMigratorSrcPath)
-      .then(function () {
-        generateMigrationIndex(done);
-      })
-      .catch(function (err) {
-        done(err);
-      });
+        .then(function () {
+          generateMigrationIndex(done);
+        })
+        .catch(function (err) {
+          done(err);
+        });
     });
   });
 

--- a/deploy/cloud-foundry/build.sh
+++ b/deploy/cloud-foundry/build.sh
@@ -45,20 +45,8 @@ chmod +x portal-proxy
 
 # Get the goose db migration tool
 export DB_MIGRATE_DIR="$CF_DIR/db-migration"
-export DB_DIR="$CF_DIR/../db/migrations"
 export GOPATH=${CACHE_DIR}/migration
 mkdir -p $GOPATH
-
-go get bitbucket.org/liamstask/goose/lib/goose
-go get github.com/lib/pq
-go get github.com/mattn/go-sqlite3
-
-# Build the migration tool
-pushd ${DB_DIR}
-go build -o migrateStratosDb
-echo "Built DB migrator"
-popd
-
 
 # Build the migration helper
 pushd ${DB_MIGRATE_DIR}

--- a/deploy/cloud-foundry/start.sh
+++ b/deploy/cloud-foundry/start.sh
@@ -17,13 +17,11 @@ $DB_MIGRATE_DIR/parseVcapServices > $STRATOS_DB_ENV
 source $STRATOS_DB_ENV
 rm $STRATOS_DB_ENV
 
-# Ensure go is on the path in order for the DB Migrations to run
-export PATH=${DB_MIGRATE_DIR}/golang/go/bin:$PATH
-export GOPATH=${DB_MIGRATE_DIR}/gopath
+# DB Migration
 
 function handleGooseResult {
   if [ $? -eq 0 ]; then
-    echo "Database successfully migrated."
+    echo "Database successfully migrated"
   else
     echo "Database migration failed"
     exit 1
@@ -34,24 +32,22 @@ function handleGooseResult {
 if [ "$CF_INSTANCE_INDEX" -eq "0" ]; then
   if [ -n "$DB_TYPE" ]; then
     echo "Attempting to migrate database"
-    pushd $DEPLOY_DIR
 
     case $DB_TYPE in
     "postgresql")
         echo "Migrating postgresql instance on $DB_HOST"
-        $DBMIGRATE_BIN_DIR/migrateStratosDb -env cf_postgres up
+        ./stratos-dbmigrator -env cf_postgres --path deploy/db up
         handleGooseResult
         ;;
     "mysql")
         echo "Migrating mysql instance on $DB_HOST"
-        $DBMIGRATE_BIN_DIR/migrateStratosDb -env cf_mysql up
+        ./stratos-dbmigrator -env cf_mysql --path deploy/db up
         handleGooseResult
         ;;
     *)
         echo Unknown DB type \'$DB_TYPE\'?
         ;;
     esac
-    popd
   fi
 else
   echo "Skipping DB migration => not index 0 ($CF_INSTANCE_INDEX)"  

--- a/deploy/db/migrations/glide.lock
+++ b/deploy/db/migrations/glide.lock
@@ -1,0 +1,30 @@
+hash: b8cfed12ac296de1f70158fd7dc2e808d855af284ef3440474ecaf92a7705fc5
+updated: 2017-10-19T14:02:50.828546051+01:00
+imports:
+- name: bitbucket.org/liamstask/goose
+  version: 8488cc47d90c8a502b1c41a462a6d9cc8ee0a895
+  subpackages:
+  - lib/goose
+- name: github.com/go-sql-driver/mysql
+  version: a0583e0143b1624142adab07e0e97fe106d99561
+- name: github.com/kylelemons/go-gypsy
+  version: 08cad365cd28a7fba23bb1e57aa43c5e18ad8bb8
+  subpackages:
+  - yaml
+- name: github.com/lib/pq
+  version: 2704adc878c21e1329f46f6e56a1c387d788ff94
+  subpackages:
+  - oid
+- name: github.com/mattn/go-sqlite3
+  version: ca5e3819723d8eeaf170ad510e7da1d6d2e94a08
+- name: github.com/ziutek/mymysql
+  version: 1d19cbf98d83564cc561192ae7d7183d795f7ac7
+  subpackages:
+  - godrv
+  - mysql
+  - native
+- name: golang.org/x/net
+  version: 59a0b19b5533c7977ddeb86b017bf507ed407b12
+  subpackages:
+  - context
+testImports: []

--- a/deploy/db/migrations/glide.yaml
+++ b/deploy/db/migrations/glide.yaml
@@ -1,0 +1,5 @@
+package: github.com/SUSE/stratos-dbmigrator
+import:
+- package: bitbucket.org/liamstask/goose/lib/goose
+- package: github.com/lib/pq
+- package: github.com/mattn/go-sqlite3

--- a/deploy/db/migrations/main.go
+++ b/deploy/db/migrations/main.go
@@ -52,14 +52,6 @@ type StratosMigrationMehod struct {
 type StratosMigrations struct {
 }
 
-// func (s *StratosMigrations) Up_20170818162837(txn *sql.Tx) {
-// 	Up_20170818162837(txn)
-// }
-
-// func (s *StratosMigrations) Up_20170818120003(txn *sql.Tx) {
-// 	Up_20170818120003(txn)
-// }
-
 // -- Sorting
 
 type By func(p1, p2 *StratosMigrationMehod) bool

--- a/deploy/db/migrations/main.go
+++ b/deploy/db/migrations/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"database/sql"
 	"flag"
 	"fmt"
 	"log"
@@ -53,13 +52,13 @@ type StratosMigrationMehod struct {
 type StratosMigrations struct {
 }
 
-func (s *StratosMigrations) Up_20170818162837(txn *sql.Tx) {
-	Up_20170818162837(txn)
-}
+// func (s *StratosMigrations) Up_20170818162837(txn *sql.Tx) {
+// 	Up_20170818162837(txn)
+// }
 
-func (s *StratosMigrations) Up_20170818120003(txn *sql.Tx) {
-	Up_20170818120003(txn)
-}
+// func (s *StratosMigrations) Up_20170818120003(txn *sql.Tx) {
+// 	Up_20170818120003(txn)
+// }
 
 // -- Sorting
 


### PR DESCRIPTION
This PR does two things:

1. It dynamically generates a go file that includes that references all of the go-based migration files, so that you don't have to modify main.go when you add a new migration.

2. It adds the build of the db migration tool to the backend build target. This will allow us to remove this from the build script used when deploying in Cloud Foundry and also allows us to us this migrator tool across all environments. We should be able to reduce the size of the postflight image since it will no longer need go to be installed.