### PR TITLE
Tested that the buildpack works on opensuse

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,4 +6,4 @@ applications:
   timeout: 180
   buildpack: https://github.com/SUSE/stratos-buildpack
   health-check-type: port
-  stack: cflinuxfs2
+

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,4 +6,3 @@ applications:
   timeout: 180
   buildpack: https://github.com/SUSE/stratos-buildpack
   health-check-type: port
-


### PR DESCRIPTION
I have tested the buildpack with cflinux and opensuse and it seems fine.

This PR remmoves the forced stack in our manifest, since we can use either stack.