### PR TITLE
Clone without access rights

### DIFF
--- a/deploy/cloud-foundry/README.md
+++ b/deploy/cloud-foundry/README.md
@@ -5,7 +5,7 @@
 The quickest way to install Stratos UI is to deploy it as a Cloud Foundry application. To do so, clone the `stratos-ui` repository, cd into the newly cloned repository and push to Cloud Foundry. This can be done with:
 
 ```
-git clone git@github.com:SUSE/stratos-ui.git
+git clone https://github.com/SUSE/stratos-ui.git
 cd stratos-ui
 cf push
 ```


### PR DESCRIPTION
Current command `git clone git@github.com:SUSE/stratos-ui.git` fails with error:

>Cloning into 'stratos-ui'...
>Permission denied (publickey).
>fatal: Could not read from remote repository.
>Please make sure you have the correct access rights
>and the repository exists.