### PR TITLE
Add `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Maintain line endings to be LF on checkout in case system defaults convert them to CRLF
+* text eol=lf
+
+# Treat images, font and icon files as binary
+*.png binary
+*.woff binary
+*.woff2 binary
+*.tff binary
+*.jpg binary
+*.ico binary


### PR DESCRIPTION
This is to prevent issues like https://github.com/SUSE/stratos-ui/issues/1322, where users can have local git configuration that converts line endings to CRLF on Windows, hence causing issues when a `cf push` is carried out.