### PR TITLE
Add separate target for building the db migrator

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "clean": "gulp clean",
     "build": "gulp clean:dist && gulp",
     "build-backend": "gulp build-backend",
+    "build-migrator": "gulp build-migrator",
     "cf-get-backend-deps": "gulp cf-get-backend-deps",
     "cf-build-backend": "gulp cf-build-backend",
     "build-cf": "gulp deploy:cf",


### PR DESCRIPTION
new build target:

npm run build-migrator

or

gulp build-migrator

This target only builds the db migrator tool