### PR TITLE
Add support for building SLE based images

### DIFF
--- a/deploy/db/scripts/run-postflight-job.k8s.sh
+++ b/deploy/db/scripts/run-postflight-job.k8s.sh
@@ -90,15 +90,7 @@ done
 EOF
 chmod +x $TEMP_SCRIPT
 
-
-# Timeout after 5 minutes
-IS_ALPINE=$(cat /etc/os-release | grep Alpine)
-
-if [ -z "${IS_ALPINE}" ]; then
-    timeout 5m ${TEMP_SCRIPT}
-else
-    timeout -t 300 ${TEMP_SCRIPT}
-fi
+timeout 5m ${TEMP_SCRIPT};
 # Remove the lock file on the shared volume
 echo "Removing the $UPGRADE_LOCK_FILENAME file from the shared upgrade volume $UPGRADE_VOLUME."
 rm /$UPGRADE_VOLUME/$UPGRADE_LOCK_FILENAME || true

--- a/deploy/db/scripts/run-postflight-job.k8s.sh
+++ b/deploy/db/scripts/run-postflight-job.k8s.sh
@@ -90,7 +90,7 @@ done
 EOF
 chmod +x $TEMP_SCRIPT
 
-timeout 5m ${TEMP_SCRIPT};
+timeout 5m ${TEMP_SCRIPT}
 # Remove the lock file on the shared volume
 echo "Removing the $UPGRADE_LOCK_FILENAME file from the shared upgrade volume $UPGRADE_VOLUME."
 rm /$UPGRADE_VOLUME/$UPGRADE_LOCK_FILENAME || true

--- a/deploy/kubernetes/build.sh
+++ b/deploy/kubernetes/build.sh
@@ -5,10 +5,10 @@ set -eu
 PROD_RELEASE=false
 DOCKER_REGISTRY=docker.io
 DOCKER_ORG=splatform
-
+BASE_IMAGE_TAG=opensuse
 TAG=$(date -u +"%Y%m%dT%H%M%SZ")
 
-while getopts ":ho:r:t:dTc" opt; do
+while getopts ":ho:r:t:dTcb:" opt; do
   case $opt in
     h)
       echo
@@ -26,6 +26,9 @@ while getopts ":ho:r:t:dTc" opt; do
       ;;
     t)
       TAG="${OPTARG}"
+      ;;
+    b)
+      BASE_IMAGE_TAG="${OPTARG}"
       ;;
     T)
       TAG="$(git describe $(git rev-list --tags --max-count=1))"
@@ -53,13 +56,14 @@ echo "PRODUCTION BUILD/RELEASE: ${PROD_RELEASE}"
 echo "REGISTRY: ${DOCKER_REGISTRY}"
 echo "ORG: ${DOCKER_ORG}"
 echo "TAG: ${TAG}"
+echo "BASE_IMAGE_TAG: ${BASE_IMAGE_TAG}"
 
 echo
 echo "Starting build"
 
 # Copy values template
 __DIRNAME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-STRATOS_UI_PATH=${__DIRNAME}/../../../stratos-ui
+STRATOS_UI_PATH=${__DIRNAME}/../../
 
 # Proxy support
 BUILD_ARGS=""
@@ -93,6 +97,8 @@ function buildAndPublishImage {
     exit 1
   fi
 
+  # Patch Dockerfile
+  patchDockerfile ${DOCKER_FILE} ${FOLDER}
   IMAGE_URL=${DOCKER_REGISTRY}/${DOCKER_ORG}/${NAME}:${TAG}
   echo Building Docker Image for ${NAME}
 
@@ -105,7 +111,7 @@ function buildAndPublishImage {
   echo Pushing Docker Image ${IMAGE_URL}
   docker push  ${IMAGE_URL}
 
-  # Update values.yaml
+  unPatchDockerfile ${DOCKER_FILE} ${FOLDER}
 
   popd > /dev/null 2>&1
 }
@@ -162,6 +168,34 @@ function pushGitTag {
   popd > /dev/null 2>&1
 }
 
+
+function patchDockerfile {
+  DOCKER_FILE=${1}
+  FOLDER=${2}
+
+  # Replace registry/organization
+  pushd ${FOLDER} > /dev/null 2>&1
+  pwd
+  sed -i "s@splatform@${DOCKER_REGISTRY}/${DOCKER_ORG}@g" ${FOLDER}/${DOCKER_FILE}
+  sed -i "s/opensuse/${BASE_IMAGE_TAG}/g" ${FOLDER}/${DOCKER_FILE}
+  popd > /dev/null 2>&1
+
+}
+
+function unPatchDockerfile {
+  DOCKER_FILE=${1}
+  FOLDER=${2}
+
+  # Replace registry/organization
+  pushd ${FOLDER} > /dev/null 2>&1
+  pwd
+  sed -i "s@${DOCKER_REGISTRY}/${DOCKER_ORG}@splatform@g" ${FOLDER}/${DOCKER_FILE}
+  sed -i "s/${BASE_IMAGE_TAG}/opensuse/g" ${FOLDER}/${DOCKER_FILE}
+  popd > /dev/null 2>&1
+
+}
+
+
 function buildProxy {
   # Use the existing build container to compile the proxy executable, and leave
   # it on the local filesystem.
@@ -183,7 +217,7 @@ function buildProxy {
              -e GROUP_ID=$(id -g) \
              --name stratos-proxy-builder \
              --volume $(pwd):/go/src/github.com/SUSE/stratos-ui \
-             ${DOCKER_REGISTRY}/${DOCKER_ORG}/stratos-proxy-builder:opensuse
+             ${DOCKER_REGISTRY}/${DOCKER_ORG}/stratos-proxy-builder:${BASE_IMAGE_TAG}
   popd > /dev/null 2>&1
   popd > /dev/null 2>&1
 
@@ -194,14 +228,6 @@ function buildProxy {
   buildAndPublishImage stratos-proxy deploy/Dockerfile.bk.k8s ${STRATOS_UI_PATH}
   # Build merged preflight & proxy image, used when deploying into multi-node k8s cluster without a shared storage backend
   buildAndPublishImage stratos-proxy-noshared deploy/Dockerfile.bk-preflight.dev ${STRATOS_UI_PATH}
-}
-
-function buildPostgres {
-  # Build and publish the container image for postgres
-  echo
-  echo "-- Build & publish the runtime container image for postgres"
-  # Pull base image locally and retag
-  buildAndPublishImage stratos-postgres Dockerfile ${STRATOS_UI_PATH}/deploy/containers/postgres
 }
 
 function buildPreflightJob {
@@ -215,16 +241,15 @@ function buildPostflightJob {
   # Build the postflight container
   echo
   echo "-- Build & publish the runtime container image for the postflight job"
-
   docker run \
              ${RUN_ARGS} \
              -it \
              --rm \
              --name postflight-builder \
              --volume $(pwd):/go/bin/ \
-             ${DOCKER_REGISTRY}/${DOCKER_ORG}/stratos-postflight-builder:opensuse
+             ${DOCKER_REGISTRY}/${DOCKER_ORG}/stratos-postflight-builder:${BASE_IMAGE_TAG}
   mv goose  ${STRATOS_UI_PATH}/
-  buildAndPublishImage stratos-postflight-job ./deploy/db/Dockerfile.k8s.postflight-job ${STRATOS_UI_PATH}
+  buildAndPublishImage stratos-postflight-job deploy/db/Dockerfile.k8s.postflight-job ${STRATOS_UI_PATH}
   rm -f ${STRATOS_UI_PATH}/goose
 }
 
@@ -241,7 +266,7 @@ function buildUI {
     -e USER_ID=$(id -u)  \
     -e GROUP_ID=$(id -g) \
     -w /usr/src/app \
-    splatform/stratos-ui-build-base:opensuse \
+    ${DOCKER_REGISTRY}/${DOCKER_ORG}/stratos-ui-build-base:${BASE_IMAGE_TAG} \
     /bin/bash ./deploy/provision.sh
 
   # Copy the artifacts from the above to the nginx container
@@ -269,7 +294,6 @@ updateTagForRelease
 
 # Build all of the components that make up the Console
 buildProxy
-buildPostgres
 buildPreflightJob
 buildPostflightJob
 buildUI

--- a/deploy/stratos-base-images/Dockerfile.stratos-go-build-base.tmpl
+++ b/deploy/stratos-base-images/Dockerfile.stratos-go-build-base.tmpl
@@ -9,7 +9,8 @@ RUN wget https://storage.googleapis.com/golang/go1.8.4.linux-amd64.tar.gz && \
     mkdir -p /go/src
 ENV PATH $PATH:/usr/local/go/bin:/go/bin
 ENV GOPATH /go
-RUN wget https://glide.sh/get && \
-    chmod +x get && \
-    ./get
+# Using modified glide install script, because the official one defaults to `curl` which is broken in SLE12
+RUN wget https://gist.githubusercontent.com/irfanhabib/be96a57865a98612ff8311662ab34513/raw/c082f1c2491380f8304c4285c37c35eb5fd361a4/glide-get-with-wget && \
+    chmod +x glide-get-with-wget && \
+    ./glide-get-with-wget
 WORKDIR /go

--- a/deploy/stratos-base-images/Dockerfile.stratos-goose-base.tmpl
+++ b/deploy/stratos-base-images/Dockerfile.stratos-goose-base.tmpl
@@ -1,2 +1,2 @@
-FROM splatform/stratos-go-build-base:opensuse
+FROM {{GO_BUILD_BASE}}
 RUN go get bitbucket.org/liamstask/goose/cmd/goose

--- a/deploy/stratos-base-images/Dockerfile.stratos-nginx-base.tmpl
+++ b/deploy/stratos-base-images/Dockerfile.stratos-nginx-base.tmpl
@@ -1,5 +1,7 @@
 FROM {{BASE_IMAGE}}
-
+{{#IS_SLE}}
+RUN zypper addrepo -G -t yum -c 'http://nginx.org/packages/sles/12' nginx
+{{/IS_SLE}}
 RUN zypper -n ref && \
     zypper -n up && \
     zypper in -y nginx

--- a/deploy/stratos-base-images/build-base-images.sh
+++ b/deploy/stratos-base-images/build-base-images.sh
@@ -9,13 +9,13 @@ PROG=$(basename ${BASH_SOURCE[0]})
 
 function usage {
     echo "usage: $PROG [-b BASE] [-r REGISTRY] [-o ORGANIZATION] [-t TAG] [-p] [h]"
-    echo "       -b Value    Base Image"
+    echo "       -b Value   Base Image"
     echo "       -r Value   Docker registry"
     echo "       -o Value   Organization in Docker registry"
-    echo "       -t Value    Tag for images"
-    echo "       -p    Push images to registry"
-    echo "       -s Is SLE"
-    echo "       -h    Help"
+    echo "       -t Value   Tag for images"
+    echo "       -p         Push images to registry"
+    echo "       -s         Is SLE"
+    echo "       -h         Help"
     exit 1
 }
 

--- a/deploy/tools/build-postflight-image-builder.sh
+++ b/deploy/tools/build-postflight-image-builder.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 DIR_NAME=$(mktemp -d)
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-docker.io}
 DOCKER_ORGANISATION=${DOCKER_ORG:-splatform}
 IMAGE_NAME=stratos-postflight-builder
 TAG=${TAG:-test}
@@ -58,9 +59,9 @@ EOT
 
 cd ${DIR_NAME}
 echo "Building image  ${DOCKER_ORGANISATION}/${IMAGE_NAME}:${TAG}"
-docker build . -t ${DOCKER_ORGANISATION}/${IMAGE_NAME}:${TAG}
+docker build . -t ${DOCKER_REGISTRY}/${DOCKER_ORGANISATION}/${IMAGE_NAME}:${TAG}
 
 if [ -n "${PUSH_IMAGE}" ]; then
     echo "Pushing image  ${DOCKER_ORGANISATION}/${IMAGE_NAME}:${TAG}"
-    docker push ${DOCKER_ORGANISATION}/${IMAGE_NAME}:${TAG}
+    docker push ${DOCKER_REGISTRY}/${DOCKER_ORGANISATION}/${IMAGE_NAME}:${TAG}
 fi

--- a/deploy/tools/build-push-proxy-builder-image.sh
+++ b/deploy/tools/build-push-proxy-builder-image.sh
@@ -5,8 +5,9 @@ DOCKER_REGISTRY=${DOCKER_REGISTRY:-docker.io}
 DOCKER_ORG=${DOCKER_ORG:-splatform}
 NAME=stratos-proxy-builder
 TAG=${TAG:-test}
+BK_BUILD_BASE=${BK_BUILD_BASE:-splatform/stratos-bk-build-base:opensuse}
 
-STRATOS_UI_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../stratos-ui"
+STRATOS_UI_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../"
 
 pushd ${STRATOS_UI_PATH}
 pushd $(git rev-parse --show-toplevel)
@@ -35,7 +36,7 @@ docker run \
        -e HOME=/stratos-ui \
        --volume ${PWD}/glide-cache:/.glide \
        --volume $PWD/../:/stratos-ui \
-       splatform/stratos-bk-build-base:opensuse \
+       ${BK_BUILD_BASE} \
        sh /stratos-ui/run-glide.sh
 
 # Generate NPM cache
@@ -44,9 +45,11 @@ docker run \
        --rm \
        --volume ${PWD}/npm-cache:/root/.npm \
        --volume $PWD/..:/stratos-ui \
-       splatform/stratos-bk-build-base:opensuse \
+       ${BK_BUILD_BASE} \
        bash  -c "cd /stratos-ui && npm install"
 
+# Patch BK Build Base
+sed -i "s@splatform/stratos-bk-build-base:opensuse@${BK_BUILD_BASE}@g" Dockerfile.bk.build
 docker build --tag ${NAME} \
              --file Dockerfile.bk.build .
 
@@ -54,7 +57,8 @@ sudo rm -rf ./glide-cache
 sudo rm -rf ./npm-cache
 rm -rf ../run-glide.sh
 rm -rf ../vendor/
-
+# Unpatch BK Build Base
+sed -i "s@${BK_BUILD_BASE}@splatform/stratos-bk-build-base:opensuse@g" Dockerfile.bk.build
 popd
 
 echo "Tag ${SHARED_IMAGE_URL} and push the shared image"

--- a/deploy/tools/build-push-proxy-builder-image.sh
+++ b/deploy/tools/build-push-proxy-builder-image.sh
@@ -48,7 +48,7 @@ docker run \
        ${BK_BUILD_BASE} \
        bash  -c "cd /stratos-ui && npm install"
 
-# Patch BK Build Base
+# Patch bk-build-base
 sed -i "s@splatform/stratos-bk-build-base:opensuse@${BK_BUILD_BASE}@g" Dockerfile.bk.build
 docker build --tag ${NAME} \
              --file Dockerfile.bk.build .


### PR DESCRIPTION
- Remove  `alpine` specific code in `run-postflight-job.k8s.sh`, since its no longer used
- Several improvements to the helm chart image build script: 
 - A `-b BASE_IMAGE_TAG` argument can now be supplied to build all images from a specific base
 - Fixed a bug where the script assumed it was running under `stratos-ui`
- A modified `glide` install script is now used because `curl` is broken in SLE12
- Added a `IS_SLE` flag to the base image builder to perform SLE12 specific actions 
