### PR TITLE
Fix app wall table app link

### DIFF
--- a/components/cloud-foundry/frontend/src/view/applications/list/table-view/table-view.directive.js
+++ b/components/cloud-foundry/frontend/src/view/applications/list/table-view/table-view.directive.js
@@ -87,18 +87,8 @@
         }
       });
 
-    this.getAppSummaryLink = getAppSummaryLink;
     this.stMiddleware = stMiddleware;
 
-    /**
-     * @name getAppSummaryLink
-     * @description Get link to application summary page
-     * @param {object} app The application object
-     * @returns {string} returns the link to the app summary page
-     */
-    function getAppSummaryLink(app) {
-      return '#/cf/applications/' + app.clusterId + '/app/' + app.metadata.guid + '/summary';
-    }
 
     function stMiddleware(tableState) {
       var stSort = tableState.sort.predicate + '_' + !tableState.sort.reverse;

--- a/components/cloud-foundry/frontend/src/view/applications/list/table-view/table-view.directive.js
+++ b/components/cloud-foundry/frontend/src/view/applications/list/table-view/table-view.directive.js
@@ -89,7 +89,6 @@
 
     this.stMiddleware = stMiddleware;
 
-
     function stMiddleware(tableState) {
       var stSort = tableState.sort.predicate + '_' + !tableState.sort.reverse;
       var sort = model.currentSortOption + '_' + model.sortAscending;

--- a/components/cloud-foundry/frontend/src/view/applications/list/table-view/table-view.html
+++ b/components/cloud-foundry/frontend/src/view/applications/list/table-view/table-view.html
@@ -26,7 +26,7 @@
     <tbody>
     <tr ng-repeat="app in tableViewCtrl.stApps">
       <td class="table-view-app-name">
-        <a ng-href="{{ tableViewCtrl.getAppSummaryLink(app) }}">{{ app.entity.name }}</a>
+        <a ui-sref="cf.applications.application.summary({ cnsiGuid: app.clusterId, guid: app.metadata.guid })">{{ app.entity.name }}</a>
       </td>
       <td>
         <div class="app-state-column">

--- a/components/cloud-foundry/frontend/test/unit/view/applications/list/table-view.directive.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/applications/list/table-view.directive.spec.js
@@ -34,7 +34,6 @@
     });
 
     describe('Controller tests', function () {
- 
       it('should be defined', function () {
         expect(applicationsTableDirectiveCtrl).toBeDefined();
       });

--- a/components/cloud-foundry/frontend/test/unit/view/applications/list/table-view.directive.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/applications/list/table-view.directive.spec.js
@@ -38,11 +38,6 @@
         expect(applicationsTableDirectiveCtrl).toBeDefined();
       });
 
-      it('should return correct URL', function () {
-        var urlString = applicationsTableDirectiveCtrl.getAppSummaryLink(apps[0]);
-        expect(urlString).toEqual('#/cf/applications/testGuid/app/appGuid/summary');
-      });
-
     });
 
   });

--- a/components/cloud-foundry/frontend/test/unit/view/applications/list/table-view.directive.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/applications/list/table-view.directive.spec.js
@@ -34,6 +34,7 @@
     });
 
     describe('Controller tests', function () {
+ 
       it('should be defined', function () {
         expect(applicationsTableDirectiveCtrl).toBeDefined();
       });


### PR DESCRIPTION
- Default hashbang prefix is now '!'
- Instead of adding '!', update to use ui-sref
- See https://docs.angularjs.org/guide/migration#commit-aa077e8