### PR TITLE
Migrate AIO image to opensuse

### DIFF
--- a/deploy/Dockerfile.all-in-one
+++ b/deploy/Dockerfile.all-in-one
@@ -1,4 +1,4 @@
-FROM splatform/stratos-aio-base
+FROM splatform/stratos-aio-base:opensuse
 
 COPY *.json ./
 COPY gulpfile.js ./

--- a/deploy/stratos-base-images/Dockerfile.stratos-aio-base.tmpl
+++ b/deploy/stratos-base-images/Dockerfile.stratos-aio-base.tmpl
@@ -1,0 +1,4 @@
+FROM  {{GO_BUILD_BASE}}
+RUN cd / && wget https://nodejs.org/dist/v6.11.4/node-v6.11.4-linux-x64.tar.xz && \
+tar -xf node-v6.11.4-linux-x64.tar.xz
+ENV PATH $PATH:/node-v6.11.4-linux-x64/bin

--- a/deploy/stratos-base-images/build-base-images.sh
+++ b/deploy/stratos-base-images/build-base-images.sh
@@ -130,7 +130,7 @@ build_bk_build_base;
 build_portal_proxy_builder;
 # Used for building the postflight job image
 build_preflight_job_base;
-#Used for building the DB image
+# Used for building the DB image
 build_mariadb_base;
 # Used for building the AIO image
 build_aio_base;

--- a/deploy/stratos-base-images/build-base-images.sh
+++ b/deploy/stratos-base-images/build-base-images.sh
@@ -112,6 +112,10 @@ build_mariadb_base(){
     build_and_push_image stratos-db-base Dockerfile.stratos-mariadb-base
 }
 
+build_aio_base(){
+    build_and_push_image stratos-aio-base Dockerfile.stratos-aio-base
+}
+
 # Base with go
 build_go_base
 # Used building the UI
@@ -126,6 +130,8 @@ build_bk_build_base;
 build_portal_proxy_builder;
 # Used for building the postflight job image
 build_preflight_job_base;
-# Used for building the DB image
+#Used for building the DB image
 build_mariadb_base;
+# Used for building the AIO image
+build_aio_base;
 rm -f mo;


### PR DESCRIPTION
Fixes failing AIO builds because all scripts have been migrated to `bash` therefore, no longer work in `alpine` which this container was previously based on.