### PR TITLE
Fix helm link in helm repository when publishing releases

### DIFF
--- a/deploy/ci/tasks/release/create-chart.yml
+++ b/deploy/ci/tasks/release/create-chart.yml
@@ -33,7 +33,7 @@ run:
 
       # Generate Helm package
       helm package console
-      cp console*.tgz ${ROOT_DIR}/helm-chart/console-helm-chart-${BASE_IMAGE}-${SHORT_GIT_TAG}.tgz
+      cp console*.tgz ${ROOT_DIR}/helm-chart/console-helm-chart-${SHORT_GIT_TAG}.tgz
       cd ${ROOT_DIR}/helm-chart/
       if [ -f ${STRATOS_UI}/index.yaml ]; then
         cp ${STRATOS_UI}/index.yaml ${ROOT_DIR}/helm-chart/

--- a/deploy/ci/tasks/release/create-chart.yml
+++ b/deploy/ci/tasks/release/create-chart.yml
@@ -22,18 +22,16 @@ run:
       # Expect this command to fail since k8s isn't available but it will initialise helm locally
       helm init || true
       ROOT_DIR=$PWD
-      BASE_IMAGE=${BASE_IMAGE:-opensuse}
       STRATOS_UI=${ROOT_DIR}/stratos-ui
       cd ${STRATOS_UI}/deploy/kubernetes/
-      GIT_TAG="$(git describe $(git rev-list --tags --max-count=1))-$(git rev-parse --short HEAD)"
-      SHORT_GIT_TAG="$(git describe $(git rev-list --tags --max-count=1))"
+      GIT_TAG="$(git describe $(git rev-list --tags --max-count=1))"
 
       cp -f ${ROOT_DIR}/helm-chart-values/values.yaml* console/values.yaml
       cp -f ${ROOT_DIR}/helm-chart-Chart/Chart.yaml* console/Chart.yaml
 
       # Generate Helm package
       helm package console
-      cp console*.tgz ${ROOT_DIR}/helm-chart/console-helm-chart-${SHORT_GIT_TAG}.tgz
+      cp console*.tgz ${ROOT_DIR}/helm-chart/console-helm-chart-${GIT_TAG}.tgz
       cd ${ROOT_DIR}/helm-chart/
       if [ -f ${STRATOS_UI}/index.yaml ]; then
         cp ${STRATOS_UI}/index.yaml ${ROOT_DIR}/helm-chart/
@@ -41,7 +39,7 @@ run:
       fi
 
       # Update Helm Repository
-      helm repo index ./ ${MERGE_INDEX} --url https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/${SHORT_GIT_TAG}/
+      helm repo index ./ ${MERGE_INDEX} --url https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/${GIT_TAG}/
       cp index.yaml ${STRATOS_UI}/
       cd ${STRATOS_UI}
       git config --global user.name ${GIT_USER}
@@ -53,6 +51,6 @@ run:
       echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
       # Update Helm repo
       git add index.yaml
-      git commit -m "Helm repository updated for tag: ${SHORT_GIT_TAG}"
+      git commit -m "Helm repository updated for tag: ${GIT_TAG}"
       git config --global push.default simple
       git push origin HEAD:master

--- a/deploy/ci/tasks/release/create-chart.yml
+++ b/deploy/ci/tasks/release/create-chart.yml
@@ -49,7 +49,7 @@ run:
       echo "${GIT_PRIVATE_KEY}" > /root/.ssh/id_rsa
       chmod 600 /root/.ssh/id_rsa
       echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-      # Update Helm repo
+      # Commit Helm Repository change
       git add index.yaml
       git commit -m "Helm repository updated for tag: ${GIT_TAG}"
       git config --global push.default simple


### PR DESCRIPTION
1. Removes base name from helm chart when updating the helm repository.
2. Remove the long `GIT_TAG` since it was not used and renames the `SHORT_GIT_TAG` to `GIT_TAG` for consistency.