### PR TITLE
Patch docker registry and organisation when publishing a helm chart

### DIFF
--- a/deploy/kubernetes/build.sh
+++ b/deploy/kubernetes/build.sh
@@ -333,6 +333,8 @@ if [ ${CONCOURSE_BUILD:-"not-set"} == "not-set" ]; then
   sed -i -e 's/DOCKER_ORGANISATION/'"${DOCKER_ORG}"'/g' values.yaml
 else
   sed -i -e 's/consoleVersion: latest/consoleVersion: '"${TAG}"'/g' console/values.yaml
+  sed -i -e 's/dockerOrg: splatform/dockerOrg: '"${DOCKER_ORG}"'/g' console/values.yaml
+  sed -i -e 's/dockerRegistry: docker.io/dockerRegistry: '"${DOCKER_REGISTRY}"'/g' console/values.yaml
   sed -i -e 's/version: 0.1.0/version: '"${RELEASE_TAG}"'/g' console/Chart.yaml
 fi
 

--- a/deploy/kubernetes/build.sh
+++ b/deploy/kubernetes/build.sh
@@ -335,6 +335,7 @@ else
   sed -i -e 's/consoleVersion: latest/consoleVersion: '"${TAG}"'/g' console/values.yaml
   sed -i -e 's/dockerOrg: splatform/dockerOrg: '"${DOCKER_ORG}"'/g' console/values.yaml
   sed -i -e 's/dockerRegistry: docker.io/dockerRegistry: '"${DOCKER_REGISTRY}"'/g' console/values.yaml
+  
   sed -i -e 's/version: 0.1.0/version: '"${RELEASE_TAG}"'/g' console/Chart.yaml
 fi
 


### PR DESCRIPTION
Updates the docker registry and docker organisation in the `console/values.yaml` when generating a helm chart.