### PR TITLE
Fix `chandler` in the console-release pipeline

### DIFF
--- a/deploy/ci/scripts/Dockerfile.github-release
+++ b/deploy/ci/scripts/Dockerfile.github-release
@@ -1,3 +1,5 @@
-FROM golang:1.8-alpine
-RUN apk update && apk add git
+FROM splatform/stratos-go-build-base:opensuse
+RUN zypper in -y ruby
+RUN gem install chandler
+RUN ln -s /usr/bin/chandler* /usr/bin/chandler
 RUN go get github.com/aktau/github-release


### PR DESCRIPTION
chandler was broken in the previous image. The image had been manually patched to include chandler.

The corresponding Dockerfile has been updated to install chandler. Image is now based on the `stratos-go-build-base`.

The image used by the CI job has been updated