### PR TITLE
Remove delete job when running in noShared mode

### DIFF
--- a/deploy/kubernetes/console/templates/post-delete.yaml
+++ b/deploy/kubernetes/console/templates/post-delete.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.noShared }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -30,3 +31,4 @@ spec:
         - sh
         - -c
         - "kubectl delete pvc,job,po --namespace {{ .Release.Namespace }} -l app={{ .Release.Name }} && kubectl delete job --namespace {{ .Release.Namespace }} -l app={{ .Release.Name }}-post-delete"
+{{- end}}


### PR DESCRIPTION
Delete Job is required to remove resources created by `Jobs`, since these are not tracked as part of a `Helm` release. 
Since no `Jobs` run in noShared mode, this task is not required.