### PR TITLE
Improve byte filter

### DIFF
--- a/build/gulp.config.js
+++ b/build/gulp.config.js
@@ -79,6 +79,7 @@
     // Files that should be run through the linter
     lintFiles: [
       paths.components + '**/*.js',
+      '!' + paths.components + '**/backend/**',
       '!' + paths.components + '**/*.mock.js',
       paths.build + '*.js',
       paths.e2e + '**/*.js'

--- a/components/app-framework/src/filters/math/bytes.filter.js
+++ b/components/app-framework/src/filters/math/bytes.filter.js
@@ -6,7 +6,7 @@
   // Private utility functions
   function getDefaultPrecision(precision) {
     if (_.isUndefined(precision)) {
-      precision = 1;
+      precision = 0;
     }
     return precision;
   }
@@ -50,12 +50,27 @@
         total === 0) {
         return '-';
       }
+
+      // Precision
       usedPrecision = getDefaultPrecision(usedPrecision);
       totalPrecision = _.isUndefined(totalPrecision) ? 0 : totalPrecision;
+
+      // Units
       var number = getNumber(total);
+      var usedNumber = null;
+
+      // Values to display
       var totalDisplay = getReducedValue(total, number, totalPrecision);
       var usedDisplay = getReducedValue(used, number, usedPrecision);
-      return usedDisplay + ' / ' + totalDisplay + ' ' + units[number];
+
+      // Is the used value too small to be accurate (for instance 20M consumed of 1GB would show as 0 of 1GB)?
+      if (usedPrecision === 0 && usedDisplay < 1) {
+        // Use the units relative to the used value instead of total (20MB of 1GB instead of 0 of 1GB)
+        usedNumber = getNumber(used);
+        usedDisplay = getReducedValue(used, usedNumber, usedPrecision);
+      }
+
+      return usedDisplay + (usedNumber ? ' ' + units[usedNumber] : '') + ' / ' + totalDisplay + ' ' + units[number];
     };
   }
 })();

--- a/components/app-framework/src/filters/math/bytes.filter.js
+++ b/components/app-framework/src/filters/math/bytes.filter.js
@@ -64,7 +64,7 @@
       var usedDisplay = getReducedValue(used, number, usedPrecision);
 
       // Is the used value too small to be accurate (for instance 20M consumed of 1GB would show as 0 of 1GB)?
-      if (usedPrecision === 0 && usedDisplay < 1) {
+      if (used !== 0 && usedPrecision === 0 && usedDisplay < 1) {
         // Use the units relative to the used value instead of total (20MB of 1GB instead of 0 of 1GB)
         usedNumber = getNumber(used);
         usedDisplay = getReducedValue(used, usedNumber, usedPrecision);

--- a/components/app-framework/src/filters/math/bytes.filter.js
+++ b/components/app-framework/src/filters/math/bytes.filter.js
@@ -53,7 +53,7 @@
 
       // Precision
       usedPrecision = getDefaultPrecision(usedPrecision);
-      totalPrecision = _.isUndefined(totalPrecision) ? 0 : totalPrecision;
+      totalPrecision = getDefaultPrecision(totalPrecision);
 
       // Units
       var number = getNumber(total);

--- a/components/app-framework/test/unit/filters/bytes.filter.spec.js
+++ b/components/app-framework/test/unit/filters/bytes.filter.spec.js
@@ -10,7 +10,7 @@
     }));
 
     it('should return a unit of bytes for a number < 1024', function () {
-      expect(bytesFilter(42)).toBe('42.0 bytes');
+      expect(bytesFilter(42)).toBe('42 bytes');
     });
 
     it('should return a whole-number of bytes if precision is 0', function () {
@@ -26,27 +26,27 @@
     });
 
     it('should return a unit of kB for a number between 1024 and 1024^2', function () {
-      expect(bytesFilter(4096)).toBe('4.0 kB');
+      expect(bytesFilter(4096, 1)).toBe('4.0 kB');
     });
 
     it('should return a unit of MB for a number between 1024^2 and 1024^3', function () {
-      expect(bytesFilter(5.5 * 1024 * 1024)).toBe('5.5 MB');
+      expect(bytesFilter(5.5 * 1024 * 1024, 1)).toBe('5.5 MB');
     });
 
     it('should return a unit of GB for a number between 1024^3 and 1024^4', function () {
-      expect(bytesFilter(6.6 * 1024 * 1024 * 1024)).toBe('6.6 GB');
+      expect(bytesFilter(6.6 * 1024 * 1024 * 1024, 1)).toBe('6.6 GB');
     });
 
     it('should return a unit of TB for a number between 1024^4 and 1024^5', function () {
-      expect(bytesFilter(7.7 * Math.pow(1024, 4))).toBe('7.7 TB');
+      expect(bytesFilter(7.7 * Math.pow(1024, 4), 1)).toBe('7.7 TB');
     });
 
     it('should return a unit of PB for a number between 1024^5 and 1024^6', function () {
-      expect(bytesFilter(8.8 * Math.pow(1024, 5))).toBe('8.8 PB');
+      expect(bytesFilter(8.8 * Math.pow(1024, 5), 1)).toBe('8.8 PB');
     });
 
     it('should return 0 bytes for a number of 0', function () {
-      expect(bytesFilter(0)).toBe('0.0 bytes');
+      expect(bytesFilter(0)).toBe('0 bytes');
     });
 
     it('should return "-" for non-numeric numbers', function () {
@@ -67,7 +67,7 @@
     });
 
     it('should return values with the correct number of digits', function () {
-      expect(usageBytesFilter([1, 42])).toBe('1.0 / 42 bytes');
+      expect(usageBytesFilter([1, 42])).toBe('1 / 42 bytes');
     });
 
     it('should display the correct precision for the total if specified', function () {
@@ -79,11 +79,11 @@
     });
 
     it('should select the unit based on the total', function () {
-      expect(usageBytesFilter([512, 4096])).toBe('0.5 / 4 kB');
+      expect(usageBytesFilter([512, 4096], 1)).toBe('0.5 / 4 kB');
     });
 
     it('should handle a used value of zero', function () {
-      expect(usageBytesFilter([0, 4096])).toBe('0.0 / 4 kB');
+      expect(usageBytesFilter([0, 4096])).toBe('0 / 4 kB');
     });
 
     it('should return "-" for any non-numeric value', function () {
@@ -96,19 +96,23 @@
     });
 
     it('should display a unit of MB for a total between 1024^2 and 1024^3', function () {
-      expect(usageBytesFilter([2 * Math.pow(1024, 2), 40 * Math.pow(1024, 2)])).toBe('2.0 / 40 MB');
+      expect(usageBytesFilter([2 * Math.pow(1024, 2), 40 * Math.pow(1024, 2)])).toBe('2 / 40 MB');
     });
 
     it('should display a unit of GB for a total between 1024^3 and 1024^4', function () {
-      expect(usageBytesFilter([2 * Math.pow(1024, 3), 40 * Math.pow(1024, 3)])).toBe('2.0 / 40 GB');
+      expect(usageBytesFilter([2 * Math.pow(1024, 3), 40 * Math.pow(1024, 3)])).toBe('2 / 40 GB');
     });
 
     it('should display a unit of TB for a total between 1024^4 and 1024^5', function () {
-      expect(usageBytesFilter([2 * Math.pow(1024, 4), 40 * Math.pow(1024, 4)])).toBe('2.0 / 40 TB');
+      expect(usageBytesFilter([2 * Math.pow(1024, 4), 40 * Math.pow(1024, 4)])).toBe('2 / 40 TB');
     });
 
     it('should display a unit of PB for a total between 1024^5 and 1024^6', function () {
-      expect(usageBytesFilter([2 * Math.pow(1024, 5), 40 * Math.pow(1024, 5)])).toBe('2.0 / 40 PB');
+      expect(usageBytesFilter([2 * Math.pow(1024, 5), 40 * Math.pow(1024, 5)])).toBe('2 / 40 PB');
+    });
+
+    it('should display a unit of used different to the total', function () {
+      expect(usageBytesFilter([21934080, 1073741824])).toBe('21 MB / 1 GB');
     });
 
   });

--- a/components/cf-app-ssh/frontend/src/view/instance-selector/instance-selector.html
+++ b/components/cf-app-ssh/frontend/src/view/instance-selector/instance-selector.html
@@ -21,7 +21,7 @@
           <td>{{ instance.state }}</td>
           <td class="instance-percent-gauge">
             <percent-gauge value="{{ instance.stats.usage.mem / instance.stats.mem_quota }}"
-                          value-text="{{ [instance.stats.usage.mem, instance.stats.mem_quota] | usageBytes:0 }}"/>
+                          value-text="{{ [instance.stats.usage.mem, instance.stats.mem_quota] | usageBytes }}"/>
           </td>
           <td class="instance-percent-gauge">
             <percent-gauge value="{{ instance.stats.usage.disk / instance.stats.disk_quota }}"

--- a/components/cloud-foundry/frontend/src/view/applications/application/summary/summary.html
+++ b/components/cloud-foundry/frontend/src/view/applications/application/summary/summary.html
@@ -220,7 +220,7 @@
         <td>{{ instance.state }}</td>
         <td class="instance-percent-gauge">
           <percent-gauge value="{{ instance.stats.usage.mem / instance.stats.mem_quota }}"
-                         value-text="{{ [instance.stats.usage.mem, instance.stats.mem_quota] | usageBytes:0 }}"/>
+                         value-text="{{ [instance.stats.usage.mem, instance.stats.mem_quota] | usageBytes }}"/>
         </td>
         <td class="instance-percent-gauge">
           <percent-gauge value="{{ instance.stats.usage.disk / instance.stats.disk_quota }}"


### PR DESCRIPTION
- filter would only show values using the total's units
- for small used totals this means we'd round down to nothing or misleading values
- for small used totals now show used as different units than total
- for example 20MB used of 1GB would show as `0 / 1GB`. Now we show `20MB / 1GB`