### PR TITLE
Fix Travis e2e-test. Error: mv error Directory not empty

### DIFF
--- a/deploy/ci/travis/run-e2e-tests.sh
+++ b/deploy/ci/travis/run-e2e-tests.sh
@@ -44,7 +44,7 @@ export CERTS_PATH=./dev-certs
 ./deploy/tools/generate_cert.sh
 
 # Move the node_modules folder - the docker build will remove it anyway
-mv ./node_modules /tmp/node_modules
+rsync -a ./node_modules /tmp/node_modules
 
 echo "Building images locally"
 ./deploy/docker-compose/build.sh -n -l
@@ -59,7 +59,7 @@ popd
 # The build cleared node_modules, so move back the one we kept
 #npm install
 rm -rf ./node_modules
-mv /tmp/node_modules ./node_modules
+rsync -a /tmp/node_modules ./node_modules
 
 set +e
 echo "Running e2e tests"


### PR DESCRIPTION
Signed-off-by: Hamza Hamidi <hamza.hamidi@orange.com>

<!--- Provide a general summary of your changes in the Title above -->
Fix mv error when trying to move the node_modules
## Description
<!--- Describe your changes in detail -->
Fix MV error encountered when running the command ./deploy/ci/travis/run-e2e-tests.sh
Moving the node_modules in line 50 & 62 causes the error ```mv: cannot move: Directory not empty```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message