### PR TITLE
Confirmation prompt for stop/restart app

### DIFF
--- a/components/cloud-foundry/frontend/i18n/en_US/app.json
+++ b/components/cloud-foundry/frontend/i18n/en_US/app.json
@@ -41,6 +41,26 @@
         "start": "Start",
         "cli": "CLI Info"
       },
+      "restart-app": {
+        "title": "Restart Application",
+        "description": "Are you sure you want to restart application {{app}}?",
+        "error-message": "There was a problem restarting this application. Please try again. If this error persists, please contact the Administrator.",
+        "button": {
+          "yes": "Restart",
+          "no": "@:buttons.cancel"
+        },
+        "success": "Application {{app}} successfully restarted"
+      },
+      "stop-app": {
+        "title": "Stop Application",
+        "description": "Are you sure you want to stop application {{app}}?",
+        "error-message": "There was a problem stopping this application. Please try again. If this error persists, please contact the Administrator.",
+        "button": {
+          "yes": "Stop",
+          "no": "@:buttons.cancel"
+        },
+        "success": "Application {{app}} successfully stopped"
+      },
       "edit-app": {
         "edit-app": "Edit App",
         "ssh-access": "Enable SSH Access",

--- a/components/cloud-foundry/frontend/src/model/application/application.model.js
+++ b/components/cloud-foundry/frontend/src/model/application/application.model.js
@@ -793,6 +793,7 @@
      * @description restart an application
      * @param {string} cnsiGuid - The GUID of the cloud-foundry server.
      * @param {string} guid - the application id
+     * @returns {promise} a promise object
      * @public
      */
     function restartApp(cnsiGuid, guid) {

--- a/components/cloud-foundry/frontend/src/model/application/application.model.js
+++ b/components/cloud-foundry/frontend/src/model/application/application.model.js
@@ -798,8 +798,8 @@
      */
     function restartApp(cnsiGuid, guid) {
 
-      stopApp(cnsiGuid, guid).then(function () {
-        startApp(cnsiGuid, guid);
+      return stopApp(cnsiGuid, guid).then(function () {
+        return startApp(cnsiGuid, guid);
       });
     }
 

--- a/components/cloud-foundry/frontend/src/view/applications/application/application.module.js
+++ b/components/cloud-foundry/frontend/src/view/applications/application/application.module.js
@@ -101,7 +101,24 @@
         name: 'app.app-info.app-actions.stop',
         id: 'stop',
         execute: function () {
-          vm.model.stopApp(cnsiGuid, vm.id);
+          var appName = vm.model.application.summary.name;
+          frameworkDialogConfirm({
+            title: 'app.app-info.stop-app.title',
+            description: $translate.instant('app.app-info.stop-app.description', { app: appName }),
+            errorMessage: 'app.app-info.stop-app.error-message',
+            submitCommit: true,
+            buttonText: {
+              yes: 'app.app-info.stop-app.button.yes',
+              no: 'app.app-info.stop-app.button.no'
+            },
+            callback: function () {
+              return vm.model.stopApp(cnsiGuid, vm.id)
+                .then(function () {
+                  var message = $translate.instant('app.app-info.stop-app.success', { app: appName });
+                  appEventService.$emit('events.NOTIFY_SUCCESS', {message: message});
+                });
+            }
+          });
         },
         disabled: true,
         icon: 'stop'
@@ -110,7 +127,24 @@
         name: 'app.app-info.app-actions.restart',
         id: 'restart',
         execute: function () {
-          vm.model.restartApp(cnsiGuid, vm.id);
+          var appName = vm.model.application.summary.name;
+          frameworkDialogConfirm({
+            title: 'app.app-info.restart-app.title',
+            description: $translate.instant('app.app-info.restart-app.description', { app: appName }),
+            errorMessage: 'app.app-info.restart-app.error-message',
+            submitCommit: true,
+            buttonText: {
+              yes: 'app.app-info.restart-app.button.yes',
+              no: 'app.app-info.restart-app.button.no'
+            },
+            callback: function () {
+              return vm.model.restartApp(cnsiGuid, vm.id)
+                .then(function () {
+                  var message = $translate.instant('app.app-info.restart-app.success', { app: appName });
+                  appEventService.$emit('events.NOTIFY_SUCCESS', {message: message});
+                });
+            }
+          });
         },
         disabled: true,
         icon: 'settings_backup_restore'

--- a/components/cloud-foundry/frontend/test/unit/view/applications/application/services/service-card.directive.spec.js
+++ b/components/cloud-foundry/frontend/test/unit/view/applications/application/services/service-card.directive.spec.js
@@ -4,6 +4,8 @@
   describe('service-card directive', function () {
     var $compile, $httpBackend, $scope, mockBindingsApi, cfServiceInstanceService;
     var APP_GUID = '6e23689c-2844-4ebf-ab69-e52ab3439f6b';
+    var SERVICE_BINDING_GUID = '571b283b-97f9-41e3-abc7-81792ee34e40';
+    var SERVICE_NAME = 'instance_123';
     var cnsiGuid = 'cnsiGuid';
     var spaceGuid = 'spaceGuid';
 
@@ -91,26 +93,28 @@
           serviceCardCtrl = element.controller('serviceCard');
         });
 
-        it('detach', function () {
-          it('should call unbindServiceFromApp', function () {
-            spyOn(cfServiceInstanceService, 'unbindServiceFromApp');
-            serviceCardCtrl.detach({
-              entity: {
-                service_bindings: [{
-                  entity: {
-                    app_guid: APP_GUID
-                  }
-                }]
-              }
-            });
-            expect(cfServiceInstanceService.unbindServiceFromApp)
-              .toHaveBeenCalled();
-            var args = cfServiceInstanceService.unbindServiceFromApp.calls.argsFor(0);
-            expect(args[0]).toBe('guid');
-            expect(args[1]).toBe('6e23689c-2844-4ebf-ab69-e52ab3439f6b');
-            expect(args[2]).toBe('571b283b-97f9-41e3-abc7-81792ee34e40');
-            expect(args[3]).toBe('instance_123');
+        it('should call unbindServiceFromApp', function () {
+          spyOn(cfServiceInstanceService, 'unbindServiceFromApp');
+          serviceCardCtrl.detach({
+            entity: {
+              name: SERVICE_NAME,
+              service_bindings: [{
+                metadata: {
+                  guid: SERVICE_BINDING_GUID
+                },
+                entity: {
+                  app_guid: APP_GUID
+                }
+              }]
+            }
           });
+          expect(cfServiceInstanceService.unbindServiceFromApp)
+            .toHaveBeenCalled();
+          var args = cfServiceInstanceService.unbindServiceFromApp.calls.argsFor(0);
+          expect(args[0]).toBe('guid');
+          expect(args[1]).toBe('6e23689c-2844-4ebf-ab69-e52ab3439f6b');
+          expect(args[2]).toBe('571b283b-97f9-41e3-abc7-81792ee34e40');
+          expect(args[3]).toBe('instance_123');
         });
       });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a confirmation prompt for the restart and stop app commands


## Motivation and Context
Restart and stop are disruptive operations, in that they cause the application to become unavailable. The CLI prompts for confirmation before executing these operations: UIs should as well.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See https://github.com/SUSE/stratos-ui/issues/1435

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Deployed on CF and run against the CF API.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message